### PR TITLE
feat(input): add password input support

### DIFF
--- a/packages/core/src/examples/input-demo.ts
+++ b/packages/core/src/examples/input-demo.ts
@@ -71,7 +71,7 @@ Type: Enter text in focused field`
   const statusText = t`${bold(fg("#FFFFFF")("Input Values:"))}
 Name: "${nameValue}" (${fg(nameColor)(nameStatus)})
 Email: "${emailValue}" (${fg(emailColor)(emailStatus)})
-Password: "${passwordValue.replace(/./g, "*")}" (${fg(passwordColor)(passwordStatus)})
+Password: "${passwordValue}" (${fg(passwordColor)(passwordStatus)})
 Comment: "${commentValue}" (${fg(commentColor)(commentStatus)})
 
 ${bold(fg("#FFAA00")(`Active Input: ${activeInputName}`))}
@@ -198,6 +198,7 @@ export function run(rendererInstance: CliRenderer): void {
     cursorColor: "#FFFF00",
     value: "",
     maxLength: 50,
+    type: "password",
   })
 
   commentInput = new InputRenderable(renderer, {

--- a/packages/core/src/renderables/Input.test.ts
+++ b/packages/core/src/renderables/Input.test.ts
@@ -1547,4 +1547,36 @@ describe("InputRenderable", () => {
         input.destroy()
       })
     })
+
+    it("should produce one mask char per emoji grapheme", async () => {
+      resetRoot()
+      const { input } = createInputRenderable({ type: "password", width: 20 })
+      input.focus()
+      input.insertText("🎍😍")
+      await renderOnce()
+
+      const frame = captureCharFrame()
+
+      expect(frame).toContain("**")
+      expect(frame).not.toContain("***")
+      expect(frame).not.toContain("🎍")
+      expect(frame).not.toContain("😍")
+
+      input.destroy()
+    })
+
+    it("should produce one mask char per ZWJ sequence", async () => {
+      resetRoot()
+      const { input } = createInputRenderable({ type: "password", width: 20 })
+      input.focus()
+      input.insertText("👨‍👩‍👧")
+      await renderOnce()
+
+      const frame = captureCharFrame()
+
+      expect(frame).toContain("*")
+      expect(frame).not.toContain("**")
+
+      input.destroy()
+    })
   })

--- a/packages/core/src/renderables/Input.test.ts
+++ b/packages/core/src/renderables/Input.test.ts
@@ -1367,6 +1367,39 @@ describe("InputRenderable", () => {
       input.destroy()
     })
 
+    it("should render visible mask chars when ascii text overflows viewport", async () => {
+      resetRoot()
+      const { input } = createInputRenderable({ type: "password", width: 5 })
+      input.focus()
+      input.insertText("abcdefgh")
+      // move cursor to start so viewport scrolls back to beginning
+      input.cursorOffset = 0
+      await renderOnce()
+
+      const frame = captureCharFrame()
+
+      // viewport at start shows first 5 mask chars
+      expect(frame).toContain("*****")
+
+      input.destroy()
+    })
+
+    it("should render visible mask chars when emoji text overflows viewport", async () => {
+      resetRoot()
+      // width 5, each emoji is display-width 2, so 3 emoji already overflow
+      const { input } = createInputRenderable({ type: "password", width: 5 })
+      input.focus()
+      input.insertText("🎍🎍🎍🎍")
+      await renderOnce()
+
+      const frame = captureCharFrame()
+
+      // viewport must show some mask chars, not be blank
+      expect(frame).toMatch(/\*+/)
+
+      input.destroy()
+    })
+
     it("should keep cursor position correct after typing in password mode", async () => {
       resetRoot()
       const { input } = createInputRenderable({ type: "password", width: 20 })

--- a/packages/core/src/renderables/Input.test.ts
+++ b/packages/core/src/renderables/Input.test.ts
@@ -1382,6 +1382,21 @@ describe("InputRenderable", () => {
       input.destroy()
     })
 
+    it("should place cursor at grapheme index after emoji input", async () => {
+      resetRoot()
+      const { input } = createInputRenderable({ type: "password", width: 20 })
+      input.focus()
+      input.insertText("🎍😍")
+      await renderOnce()
+
+      const frame: CapturedFrame = captureSpans()
+
+      // 2 emoji graphemes -> cursor at column 2 (not 4 which is display-width sum)
+      expect(frame.cursor).toEqual([input.x + 3, input.y + 1])
+
+      input.destroy()
+    })
+
      it("should not affect text mode rendering", async () => {
        resetRoot()
        const { input } = createInputRenderable({ width: 20 })

--- a/packages/core/src/renderables/Input.test.ts
+++ b/packages/core/src/renderables/Input.test.ts
@@ -1397,6 +1397,40 @@ describe("InputRenderable", () => {
       input.destroy()
     })
 
+    it("should place cursor correctly mid-string with mixed emoji and ascii", async () => {
+      resetRoot()
+      const { input } = createInputRenderable({ type: "password", width: 20 })
+      input.focus()
+      input.insertText("a🎍b")
+      // move cursor left once to sit between 🎍 and b
+      input.moveCursorLeft()
+      await renderOnce()
+
+      const frame: CapturedFrame = captureSpans()
+
+      // "a🎍" = 2 graphemes -> cursor at column 2
+      expect(frame.cursor).toEqual([input.x + 3, input.y + 1])
+
+      input.destroy()
+    })
+
+    it("should place cursor correctly after ZWJ sequence", async () => {
+      resetRoot()
+      const { input } = createInputRenderable({ type: "password", width: 20 })
+      input.focus()
+      input.insertText("👨‍👩‍👧a")
+      // move cursor left once to sit between ZWJ and a
+      input.moveCursorLeft()
+      await renderOnce()
+
+      const frame: CapturedFrame = captureSpans()
+
+      // ZWJ = 1 grapheme -> cursor at column 1
+      expect(frame.cursor).toEqual([input.x + 2, input.y + 1])
+
+      input.destroy()
+    })
+
      it("should not affect text mode rendering", async () => {
        resetRoot()
        const { input } = createInputRenderable({ width: 20 })

--- a/packages/core/src/renderables/Input.test.ts
+++ b/packages/core/src/renderables/Input.test.ts
@@ -1382,19 +1382,70 @@ describe("InputRenderable", () => {
       input.destroy()
     })
 
-    it("should not affect text mode rendering", async () => {
-      resetRoot()
-      const { input } = createInputRenderable({ width: 20 })
-      input.focus()
-      input.insertText("hello")
-      await renderOnce()
+     it("should not affect text mode rendering", async () => {
+       resetRoot()
+       const { input } = createInputRenderable({ width: 20 })
+       input.focus()
+       input.insertText("hello")
+       await renderOnce()
 
-      const frame = captureCharFrame()
+       const frame = captureCharFrame()
 
-      expect(frame).toContain("hello")
-      expect(frame).not.toContain("*****")
+       expect(frame).toContain("hello")
+       expect(frame).not.toContain("*****")
 
-      input.destroy()
-    })
-  })
+       input.destroy()
+     })
+
+     it("should jump to end on moveWordForward in password mode", () => {
+       const { input } = createInputRenderable({ type: "password" })
+       input.focus()
+       input.insertText("hello world")
+       input.cursorOffset = 0
+       input.moveWordForward()
+       expect(input.cursorOffset).toBe(11)
+     })
+
+     it("should jump to start on moveWordBackward in password mode", () => {
+       const { input } = createInputRenderable({ type: "password" })
+       input.focus()
+       input.insertText("hello world")
+       input.moveWordBackward()
+       expect(input.cursorOffset).toBe(0)
+     })
+
+     it("should delete all text on deleteWordBackward in password mode", () => {
+       const { input } = createInputRenderable({ type: "password" })
+       input.focus()
+       input.insertText("hello world")
+       input.deleteWordBackward()
+       expect(input.value).toBe("")
+     })
+
+     it("should delete all text on deleteWordForward in password mode", () => {
+       const { input } = createInputRenderable({ type: "password" })
+       input.focus()
+       input.insertText("hello world")
+       input.cursorOffset = 0
+       input.deleteWordForward()
+       expect(input.value).toBe("")
+     })
+
+     it("should return empty string from getSelectedText in password mode", () => {
+       const { input } = createInputRenderable({ type: "password" })
+       input.focus()
+       input.insertText("secret")
+       input.selectAll()
+       expect(input.getSelectedText()).toBe("")
+     })
+
+     it("should use normal word navigation in text mode (regression)", () => {
+       const { input } = createInputRenderable({})
+       input.focus()
+       input.insertText("hello world")
+       input.cursorOffset = 0
+       input.moveWordForward()
+       expect(input.cursorOffset).toBe(6)
+     })
+   })
 })

--- a/packages/core/src/renderables/Input.test.ts
+++ b/packages/core/src/renderables/Input.test.ts
@@ -3,8 +3,9 @@ import { InputRenderable, type InputRenderableOptions, InputRenderableEvents } f
 import { decodePasteBytes } from "../lib/paste.js"
 import { createTestRenderer } from "../testing/test-renderer.js"
 import type { KeyEvent } from "../lib/KeyHandler.js"
+import type { CapturedFrame } from "../types.js"
 
-const { renderer, mockInput } = await createTestRenderer({})
+const { renderer, mockInput, captureCharFrame, captureSpans, renderOnce } = await createTestRenderer({})
 
 function createInputRenderable(options: InputRenderableOptions): { input: InputRenderable; root: any } {
   if (!renderer) {
@@ -16,6 +17,12 @@ function createInputRenderable(options: InputRenderableOptions): { input: InputR
   renderer.requestRender()
 
   return { input: inputRenderable, root: renderer.root }
+}
+
+function resetRoot(): void {
+  for (const child of renderer.root.getChildren()) {
+    child.destroy()
+  }
 }
 
 describe("InputRenderable", () => {
@@ -1279,6 +1286,115 @@ describe("InputRenderable", () => {
       expect(input.type).toBe("text")
       input.type = "password"
       expect(input.type).toBe("password")
+    })
+
+    it("should display mask chars instead of real text", async () => {
+      resetRoot()
+      const { input } = createInputRenderable({ type: "password", width: 20 })
+      input.focus()
+      input.insertText("hello")
+      await renderOnce()
+
+      const frame = captureCharFrame()
+
+      expect(frame).toContain("*****")
+      expect(frame).not.toContain("hello")
+
+      input.destroy()
+    })
+
+    it("should use custom maskChar", async () => {
+      resetRoot()
+      const { input } = createInputRenderable({ type: "password", maskChar: "●", width: 20 })
+      input.focus()
+      input.insertText("abc")
+      await renderOnce()
+
+      const frame = captureCharFrame()
+
+      expect(frame).toContain("●●●")
+      expect(frame).not.toContain("abc")
+
+      input.destroy()
+    })
+
+    it("should show placeholder when empty", async () => {
+      resetRoot()
+      const { input } = createInputRenderable({ type: "password", placeholder: "Enter password", width: 30 })
+      await renderOnce()
+
+      const frame = captureCharFrame()
+
+      expect(frame).toContain("Enter password")
+
+      input.destroy()
+    })
+
+    it("should hide placeholder when text is entered", async () => {
+      resetRoot()
+      const { input } = createInputRenderable({ type: "password", placeholder: "Enter password", width: 30 })
+      input.focus()
+      input.insertText("x")
+      await renderOnce()
+
+      const frame = captureCharFrame()
+
+      expect(frame).toContain("*")
+      expect(frame).not.toContain("Enter password")
+
+      input.destroy()
+    })
+
+    it("should fill the configured background while masked", async () => {
+      resetRoot()
+      const { input } = createInputRenderable({
+        type: "password",
+        value: "abc",
+        width: 8,
+        backgroundColor: "#123456",
+      })
+      await renderOnce()
+
+      const frame = captureSpans()
+      const inputLine = frame.lines[input.y]
+      const maskedSpan = inputLine?.spans.find((span) => span.text.includes("***"))
+
+      expect(maskedSpan).toBeDefined()
+      expect(maskedSpan?.bg.r).toBeCloseTo(0x12 / 255)
+      expect(maskedSpan?.bg.g).toBeCloseTo(0x34 / 255)
+      expect(maskedSpan?.bg.b).toBeCloseTo(0x56 / 255)
+
+      input.destroy()
+    })
+
+    it("should keep cursor position correct after typing in password mode", async () => {
+      resetRoot()
+      const { input } = createInputRenderable({ type: "password", width: 20 })
+      input.focus()
+      input.insertText("hello")
+      await renderOnce()
+
+      const frame: CapturedFrame = captureSpans()
+
+      expect(input.cursorOffset).toBe(5)
+      expect(frame.cursor).toEqual([input.x + 6, input.y + 1])
+
+      input.destroy()
+    })
+
+    it("should not affect text mode rendering", async () => {
+      resetRoot()
+      const { input } = createInputRenderable({ width: 20 })
+      input.focus()
+      input.insertText("hello")
+      await renderOnce()
+
+      const frame = captureCharFrame()
+
+      expect(frame).toContain("hello")
+      expect(frame).not.toContain("*****")
+
+      input.destroy()
     })
   })
 })

--- a/packages/core/src/renderables/Input.test.ts
+++ b/packages/core/src/renderables/Input.test.ts
@@ -1439,13 +1439,112 @@ describe("InputRenderable", () => {
        expect(input.getSelectedText()).toBe("")
      })
 
-     it("should use normal word navigation in text mode (regression)", () => {
-       const { input } = createInputRenderable({})
-       input.focus()
-       input.insertText("hello world")
-       input.cursorOffset = 0
-       input.moveWordForward()
-       expect(input.cursorOffset).toBe(6)
-     })
-   })
-})
+      it("should use normal word navigation in text mode (regression)", () => {
+        const { input } = createInputRenderable({})
+        input.focus()
+        input.insertText("hello world")
+        input.cursorOffset = 0
+        input.moveWordForward()
+        expect(input.cursorOffset).toBe(6)
+      })
+
+      it("should switch rendering from text to password at runtime", async () => {
+        resetRoot()
+        const { input } = createInputRenderable({ width: 20 })
+        input.focus()
+        input.insertText("hello")
+        await renderOnce()
+        expect(captureCharFrame()).toContain("hello")
+
+        input.type = "password"
+        await renderOnce()
+        const frame = captureCharFrame()
+        expect(frame).toContain("*****")
+        expect(frame).not.toContain("hello")
+
+        input.destroy()
+      })
+
+      it("should switch rendering from password to text at runtime", async () => {
+        resetRoot()
+        const { input } = createInputRenderable({ type: "password", width: 20 })
+        input.focus()
+        input.insertText("hello")
+        await renderOnce()
+        expect(captureCharFrame()).toContain("*****")
+
+        input.type = "text"
+        await renderOnce()
+        const frame = captureCharFrame()
+        expect(frame).toContain("hello")
+        expect(frame).not.toContain("*****")
+
+        input.destroy()
+      })
+
+      it("should update rendering when maskChar changes at runtime", async () => {
+        resetRoot()
+        const { input } = createInputRenderable({ type: "password", width: 20 })
+        input.focus()
+        input.insertText("abc")
+        await renderOnce()
+        expect(captureCharFrame()).toContain("***")
+
+        input.maskChar = "●"
+        await renderOnce()
+        const frame = captureCharFrame()
+        expect(frame).toContain("●●●")
+        expect(frame).not.toContain("***")
+
+        input.destroy()
+      })
+
+      it("should respect maxLength in password mode", () => {
+        const { input } = createInputRenderable({ type: "password", maxLength: 5 })
+        input.focus()
+        input.insertText("hello world")
+        expect(input.value).toBe("hello")
+        expect(input.value.length).toBe(5)
+      })
+
+      it("should handle paste in password mode", () => {
+        const { input } = createInputRenderable({ type: "password" })
+        input.focus()
+        const pasteEvent = { bytes: new TextEncoder().encode("pasted") }
+        input.handlePaste(pasteEvent as any)
+        expect(input.value).toBe("pasted")
+      })
+
+      it("should emit INPUT event with real text in password mode", () => {
+        const { input } = createInputRenderable({ type: "password" })
+        input.focus()
+        const received: string[] = []
+        input.on(InputRenderableEvents.INPUT, (v: string) => received.push(v))
+        input.insertText("a")
+        expect(received).toEqual(["a"])
+      })
+
+      it("should emit CHANGE event with real text in password mode", () => {
+        const { input } = createInputRenderable({ type: "password" })
+        input.focus()
+        const received: string[] = []
+        input.on(InputRenderableEvents.CHANGE, (v: string) => received.push(v))
+        input.insertText("secret")
+        input.blur()
+        expect(received).toEqual(["secret"])
+      })
+
+      it("should handle programmatic value set in password mode", async () => {
+        resetRoot()
+        const { input } = createInputRenderable({ type: "password", width: 20 })
+        input.value = "hello"
+        await renderOnce()
+        const frame = captureCharFrame()
+        expect(frame).toContain("*****")
+        expect(frame).not.toContain("hello")
+        expect(input.value).toBe("hello")
+
+        input.destroy()
+      })
+    })
+  })

--- a/packages/core/src/renderables/Input.test.ts
+++ b/packages/core/src/renderables/Input.test.ts
@@ -1225,4 +1225,60 @@ describe("InputRenderable", () => {
       expect(input.cursorOffset).toBe(5)
     })
   })
+
+  describe("Password Mode", () => {
+    it("should default type to 'text'", () => {
+      const { input } = createInputRenderable({})
+      expect(input.type).toBe("text")
+    })
+
+    it("should default maskChar to '*'", () => {
+      const { input } = createInputRenderable({})
+      expect(input.maskChar).toBe("*")
+    })
+
+    it("should accept type: 'password' in options", () => {
+      const { input } = createInputRenderable({ type: "password" })
+      expect(input.type).toBe("password")
+    })
+
+    it("should accept custom maskChar in options", () => {
+      const { input } = createInputRenderable({ maskChar: "●" })
+      expect(input.maskChar).toBe("●")
+    })
+
+    it("should throw when maskChar is empty string", () => {
+      const { input } = createInputRenderable({})
+      expect(() => {
+        input.maskChar = ""
+      }).toThrow()
+    })
+
+    it("should throw when maskChar is multi-char", () => {
+      const { input } = createInputRenderable({})
+      expect(() => {
+        input.maskChar = "ab"
+      }).toThrow()
+    })
+
+    it("should accept single-char maskChar", () => {
+      const { input } = createInputRenderable({})
+      input.maskChar = "●"
+      expect(input.maskChar).toBe("●")
+    })
+
+    it("should return real text from value in password mode", () => {
+      const { input } = createInputRenderable({ type: "password" })
+      input.focus()
+      input.insertText("hello")
+      expect(input.value).toBe("hello")
+    })
+
+    it("should update type at runtime", () => {
+      const { input } = createInputRenderable({})
+      expect(input.type).toBe("text")
+      input.type = "password"
+      expect(input.type).toBe("password")
+    })
+  })
 })

--- a/packages/core/src/renderables/Input.ts
+++ b/packages/core/src/renderables/Input.ts
@@ -320,7 +320,8 @@ export class InputRenderable extends TextareaRenderable {
       return
     }
 
-    const masked = this._maskChar.repeat(text.length)
+    const graphemeCount = [...new Intl.Segmenter().segment(text)].length
+    const masked = this._maskChar.repeat(graphemeCount)
     const viewport = this.editorView.getViewport()
     const offsetX = viewport.offsetX
     const sliced = masked.slice(offsetX, offsetX + this.width)

--- a/packages/core/src/renderables/Input.ts
+++ b/packages/core/src/renderables/Input.ts
@@ -15,12 +15,11 @@ export interface InputRenderableOptions extends Omit<
   TextareaOptions,
   "height" | "minHeight" | "maxHeight" | "initialValue"
 > {
-  /** Initial text value (newlines are stripped) */
   value?: string
-  /** Maximum number of characters allowed */
   maxLength?: number
-  /** Placeholder text (Input only supports string, not StyledText) */
   placeholder?: string
+  type?: "text" | "password"
+  maskChar?: string
 }
 
 // TODO: make this just plain strings instead of an enum (same for other events)
@@ -44,6 +43,8 @@ export enum InputRenderableEvents {
 export class InputRenderable extends TextareaRenderable {
   private _maxLength: number
   private _lastCommittedValue: string = ""
+  private _type: "text" | "password"
+  private _maskChar: string
 
   // Only specify defaults that differ from TextareaRenderable/EditBufferRenderable
   private static readonly defaultOptions = {
@@ -52,6 +53,8 @@ export class InputRenderable extends TextareaRenderable {
     // Input-specific
     maxLength: 1000,
     value: "",
+    type: "text" as "text" | "password",
+    maskChar: "*",
   } satisfies Partial<InputRenderableOptions>
 
   constructor(ctx: RenderContext, options: InputRenderableOptions) {
@@ -78,6 +81,8 @@ export class InputRenderable extends TextareaRenderable {
 
     this._maxLength = maxLength
     this._lastCommittedValue = this.plainText
+    this._type = options.type ?? defaults.type
+    this._maskChar = options.maskChar ?? defaults.maskChar
 
     // Set cursor to end of initial value
     if (initialValue) {
@@ -230,6 +235,27 @@ export class InputRenderable extends TextareaRenderable {
 
   public get maxLength(): number {
     return this._maxLength
+  }
+
+  public set type(type: "text" | "password") {
+    this._type = type
+    this.requestRender()
+  }
+
+  public get type(): "text" | "password" {
+    return this._type
+  }
+
+  public set maskChar(maskChar: string) {
+    if (maskChar.length !== 1) {
+      throw new Error("maskChar must be exactly 1 character")
+    }
+    this._maskChar = maskChar
+    this.requestRender()
+  }
+
+  public get maskChar(): string {
+    return this._maskChar
   }
 
   public override set placeholder(placeholder: string) {

--- a/packages/core/src/renderables/Input.ts
+++ b/packages/core/src/renderables/Input.ts
@@ -1,3 +1,4 @@
+import type { OptimizedBuffer } from "../buffer.js"
 import type { PasteEvent } from "../lib/KeyHandler.js"
 import { decodePasteBytes, stripAnsiSequences } from "../lib/paste.js"
 import type { RenderContext } from "../types.js"
@@ -256,6 +257,45 @@ export class InputRenderable extends TextareaRenderable {
 
   public get maskChar(): string {
     return this._maskChar
+  }
+
+  protected override renderSelf(buffer: OptimizedBuffer): void {
+    if (this._type !== "password") {
+      super.renderSelf(buffer)
+      return
+    }
+
+    const bg = this._backgroundColor
+    const fg = this._textColor
+
+    buffer.fillRect(this.x, this.y, this.width, 1, bg)
+
+    const text = this.plainText
+
+    if (text.length === 0) {
+      const placeholder = this.placeholder
+      if (placeholder) {
+        buffer.drawText(placeholder, this.x, this.y, this.placeholderColor, bg)
+      }
+      return
+    }
+
+    const masked = this._maskChar.repeat(text.length)
+    const viewport = this.editorView.getViewport()
+    const offsetX = viewport.offsetX
+    const sliced = masked.slice(offsetX, offsetX + this.width)
+
+    const sel = this.editorView.getSelection()
+    const selection = sel
+      ? {
+          start: Math.max(0, sel.start - offsetX),
+          end: Math.max(0, sel.end - offsetX),
+          bgColor: this._selectionBg,
+          fgColor: this._selectionFg,
+        }
+      : undefined
+
+    buffer.drawText(sliced, this.x, this.y, fg, bg, this._defaultAttributes, selection)
   }
 
   public override set placeholder(placeholder: string) {

--- a/packages/core/src/renderables/Input.ts
+++ b/packages/core/src/renderables/Input.ts
@@ -183,12 +183,22 @@ export class InputRenderable extends TextareaRenderable {
   }
 
   public override deleteWordBackward(): boolean {
+    if (this._type === "password") {
+      const result = super.deleteToLineStart()
+      this.emit(InputRenderableEvents.INPUT, this.plainText)
+      return result
+    }
     const result = super.deleteWordBackward()
     this.emit(InputRenderableEvents.INPUT, this.plainText)
     return result
   }
 
   public override deleteWordForward(): boolean {
+    if (this._type === "password") {
+      const result = super.deleteToLineEnd()
+      this.emit(InputRenderableEvents.INPUT, this.plainText)
+      return result
+    }
     const result = super.deleteWordForward()
     this.emit(InputRenderableEvents.INPUT, this.plainText)
     return result
@@ -257,6 +267,31 @@ export class InputRenderable extends TextareaRenderable {
 
   public get maskChar(): string {
     return this._maskChar
+  }
+
+  public override getSelectedText(): string {
+    if (this._type === "password") return ""
+    return super.getSelectedText()
+  }
+
+  public override moveWordForward(options?: { select?: boolean }): boolean {
+    if (this._type !== "password") return super.moveWordForward(options)
+    const select = options?.select ?? false
+    this.updateSelectionForMovement(select, true)
+    this.editBuffer.setCursorByOffset(this.plainText.length)
+    this.updateSelectionForMovement(select, false)
+    this.requestRender()
+    return true
+  }
+
+  public override moveWordBackward(options?: { select?: boolean }): boolean {
+    if (this._type !== "password") return super.moveWordBackward(options)
+    const select = options?.select ?? false
+    this.updateSelectionForMovement(select, true)
+    this.editBuffer.setCursorByOffset(0)
+    this.updateSelectionForMovement(select, false)
+    this.requestRender()
+    return true
   }
 
   protected override renderSelf(buffer: OptimizedBuffer): void {

--- a/packages/core/src/renderables/Input.ts
+++ b/packages/core/src/renderables/Input.ts
@@ -16,10 +16,15 @@ export interface InputRenderableOptions extends Omit<
   TextareaOptions,
   "height" | "minHeight" | "maxHeight" | "initialValue"
 > {
+  /** Initial text value (newlines are stripped) */
   value?: string
+  /** Maximum number of characters allowed */
   maxLength?: number
+  /** Placeholder text (Input only supports string, not StyledText) */
   placeholder?: string
+  /** Input type, use "password" to mask characters */
   type?: "text" | "password"
+  /** Character used to mask input in password mode (must be exactly 1 character) */
   maskChar?: string
 }
 

--- a/packages/core/src/renderables/Input.ts
+++ b/packages/core/src/renderables/Input.ts
@@ -54,7 +54,7 @@ export class InputRenderable extends TextareaRenderable {
     // Input-specific
     maxLength: 1000,
     value: "",
-    type: "text" as "text" | "password",
+    type: "text" as const,
     maskChar: "*",
   } satisfies Partial<InputRenderableOptions>
 

--- a/packages/core/src/renderables/Input.ts
+++ b/packages/core/src/renderables/Input.ts
@@ -299,6 +299,66 @@ export class InputRenderable extends TextareaRenderable {
     return true
   }
 
+  // Maps a display-width column in the real text to a grapheme index.
+  // Needed in password mode because mask chars are always width-1 while
+  // the real text may contain wide characters (emoji, CJK, etc.).
+  private _displayColToGraphemeIndex(text: string, displayCol: number): number {
+    let col = 0
+    let idx = 0
+    for (const { segment } of new Intl.Segmenter().segment(text)) {
+      if (col >= displayCol) break
+      col += this._graphemeDisplayWidth(segment)
+      idx++
+    }
+    return idx
+  }
+
+  // Approximates terminal display width for a grapheme cluster.
+  // Matches the wcwidth/unicode ranges used by the Zig rendering layer.
+  private _graphemeDisplayWidth(g: string): number {
+    const cp = g.codePointAt(0)
+    if (cp === undefined) return 1
+    if (
+      (cp >= 0x1100 && cp <= 0x115f) ||
+      cp === 0x2329 || cp === 0x232a ||
+      (cp >= 0x2e80 && cp <= 0x303e) ||
+      (cp >= 0x3040 && cp <= 0x33ff) ||
+      (cp >= 0x3400 && cp <= 0x4dbf) ||
+      (cp >= 0x4e00 && cp <= 0x9fff) ||
+      (cp >= 0xa000 && cp <= 0xa4cf) ||
+      (cp >= 0xac00 && cp <= 0xd7af) ||
+      (cp >= 0xf900 && cp <= 0xfaff) ||
+      (cp >= 0xfe10 && cp <= 0xfe1f) ||
+      (cp >= 0xfe30 && cp <= 0xfe4f) ||
+      (cp >= 0xff00 && cp <= 0xff60) ||
+      (cp >= 0xffe0 && cp <= 0xffe6) ||
+      (cp >= 0x1f004 && cp <= 0x1f0cf) ||
+      (cp >= 0x1f300 && cp <= 0x1f9ff) ||
+      (cp >= 0x20000 && cp <= 0x2fffd) ||
+      (cp >= 0x30000 && cp <= 0x3fffd)
+    ) return 2
+    return 1
+  }
+
+  protected override renderCursor(buffer: OptimizedBuffer): void {
+    if (this._type !== "password") {
+      super.renderCursor(buffer)
+      return
+    }
+    if (!this._showCursor || !this._focused) return
+
+    const text = this.plainText
+    const logicalCol = this.logicalCursor.col
+    const graphemeIdx = this._displayColToGraphemeIndex(text, logicalCol)
+    const viewport = this.editorView.getViewport()
+    const col = graphemeIdx - viewport.offsetX
+
+    const cursorX = this._screenX + col + 1
+    const cursorY = this._screenY + 1
+    this._ctx.setCursorPosition(cursorX, cursorY, true)
+    this._ctx.setCursorStyle({ ...this._cursorStyle, color: this._cursorColor })
+  }
+
   protected override renderSelf(buffer: OptimizedBuffer): void {
     if (this._type !== "password") {
       super.renderSelf(buffer)

--- a/packages/core/src/renderables/Input.ts
+++ b/packages/core/src/renderables/Input.ts
@@ -383,14 +383,14 @@ export class InputRenderable extends TextareaRenderable {
     const graphemeCount = [...new Intl.Segmenter().segment(text)].length
     const masked = this._maskChar.repeat(graphemeCount)
     const viewport = this.editorView.getViewport()
-    const offsetX = viewport.offsetX
-    const sliced = masked.slice(offsetX, offsetX + this.width)
+    const graphemeOffsetX = this._displayColToGraphemeIndex(text, viewport.offsetX)
+    const sliced = masked.slice(graphemeOffsetX, graphemeOffsetX + this.width)
 
     const sel = this.editorView.getSelection()
     const selection = sel
       ? {
-          start: Math.max(0, sel.start - offsetX),
-          end: Math.max(0, sel.end - offsetX),
+          start: Math.max(0, this._displayColToGraphemeIndex(text, sel.start) - graphemeOffsetX),
+          end: Math.max(0, this._displayColToGraphemeIndex(text, sel.end) - graphemeOffsetX),
           bgColor: this._selectionBg,
           fgColor: this._selectionFg,
         }

--- a/packages/web/src/content/docs/components/input.mdx
+++ b/packages/web/src/content/docs/components/input.mdx
@@ -63,6 +63,38 @@ const input = new InputRenderable(renderer, {
 })
 ```
 
+## Password Input
+
+Use the `type` property to create a password input that masks characters:
+
+```typescript
+const passwordInput = new InputRenderable(renderer, {
+  id: "password-input",
+  width: 25,
+  placeholder: "Enter password...",
+  type: "password",
+  maskChar: "*",
+})
+
+passwordInput.on(InputRenderableEvents.CHANGE, (value) => {
+  console.log("Password submitted:", value)
+})
+
+passwordInput.focus()
+renderer.root.add(passwordInput)
+```
+
+You can customize the mask character:
+
+```typescript
+const passwordInput = Input({
+  width: 25,
+  placeholder: "Enter password...",
+  type: "password",
+  maskChar: "•",
+})
+```
+
 ## Events
 
 ### Input event
@@ -116,6 +148,8 @@ input.value = "New value"
 | `width`                  | `number`                               | -            | Input field width            |
 | `value`                  | `string`                               | `""`         | Initial text value           |
 | `placeholder`            | `string`                               | `""`         | Placeholder text when empty  |
+| `type`                   | `"text" \| "password"`                 | `"text"`     | Input type. Use 'password' to mask input with the mask character. |
+| `maskChar`               | `string`                               | `"*"`        | Character used to mask input in password mode. Must be exactly 1 character. |
 | `maxLength`              | `number`                               | `1000`       | Maximum number of characters |
 | `backgroundColor`        | `string \| RGBA`                       | -            | Background when unfocused    |
 | `focusedBackgroundColor` | `string \| RGBA`                       | -            | Background when focused      |


### PR DESCRIPTION
Adds `type: "password"` support to the existing `<input>` component, masking
typed characters without any changes to the native rendering layer.

## What's new
- **`type` option** - `"text"` (default) or `"password"`
- **`maskChar` option** - character used for masking, default `"*"`, must be
  exactly 1 character; configurable at construction time or at runtime
- Both options have getters/setters and trigger a re-render on change
## Behaviour in password mode
- Typed characters are displayed as `maskChar`; `input.value` always returns
  the real text
- All events (`INPUT`, `CHANGE`, `ENTER`) emit the real value, not the masked
  one
- `getSelectedText()` returns `""` - clipboard-safe by default
- Word-boundary navigation (`Ctrl+←/→`) jumps to absolute start/end instead
  of word boundaries
- Word deletion (`Ctrl+Backspace/Delete`) deletes to start/end of the field
- Placeholder renders normally when the field is empty
- Horizontal scrolling works correctly on long passwords
## Usage
```ts
// Renderable API
const input = new InputRenderable(renderer, {
  type: "password",
  maskChar: "●",   // optional, defaults to "*"
  placeholder: "Enter password…",
})
// React / Solid - props surface automatically
<Input type="password" maskChar="•" />