### PR TITLE
fix(renderable): ensure rendering is requested after highlight updates

### DIFF
--- a/packages/core/src/renderables/Code.ts
+++ b/packages/core/src/renderables/Code.ts
@@ -253,6 +253,7 @@ export class CodeRenderable extends TextBufferRenderable {
       const result = await this._treeSitterClient.highlightOnce(content, filetype)
 
       if (snapshotId !== this._highlightSnapshotId) {
+        this.requestRender()
         return
       }
 
@@ -273,6 +274,7 @@ export class CodeRenderable extends TextBufferRenderable {
       }
 
       if (snapshotId !== this._highlightSnapshotId) {
+        this.requestRender()
         return
       }
 
@@ -299,6 +301,7 @@ export class CodeRenderable extends TextBufferRenderable {
         chunks = await this.transformChunks(chunks, context)
 
         if (snapshotId !== this._highlightSnapshotId) {
+          this.requestRender()
           return
         }
 
@@ -317,6 +320,7 @@ export class CodeRenderable extends TextBufferRenderable {
       this.requestRender()
     } catch (error) {
       if (snapshotId !== this._highlightSnapshotId) {
+        this.requestRender()
         return
       }
 


### PR DESCRIPTION
Fix: #964 

Hi @simonklee, 
Now before returning early for stale updates in highlighting, it requests a new render to get the new updates for highlighting

Hope this is fine and let me know if any changes are needed.
Thanks