### PR TITLE
fix(core): refresh dimensions after resize debounce

### DIFF
--- a/packages/core/src/renderer.ts
+++ b/packages/core/src/renderer.ts
@@ -3909,11 +3909,18 @@ export class CliRenderer extends EventEmitter implements RenderContext {
     if (this._isDestroyed) return
     const resize = () => {
       const stdout = this.stdout as NodeJS.WriteStream & { _refreshSize?: () => void }
+      const stdin = this.stdin as NodeJS.ReadStream & {
+        columns?: number
+        rows?: number
+        isTTY?: boolean
+        _refreshSize?: () => void
+      }
+      const sizeSource = !stdout.isTTY && stdin.isTTY ? stdin : stdout
       // PTY bridges can deliver SIGWINCH before the stream's cached dimensions reflect the new window size.
-      stdout._refreshSize?.()
-      const width = stdout.columns
-      const height = stdout.rows
-      if (width > 0 && height > 0) this.processResize(width, height)
+      sizeSource._refreshSize?.()
+      const width = sizeSource.columns
+      const height = sizeSource.rows
+      if (width && width > 0 && height && height > 0) this.processResize(width, height)
     }
     if (this._splitHeight > 0) {
       resize()

--- a/packages/core/src/renderer.ts
+++ b/packages/core/src/renderer.ts
@@ -916,9 +916,7 @@ export class CliRenderer extends EventEmitter implements RenderContext {
 
   private _useConsole: boolean = true
   private sigwinchHandler: () => void = (() => {
-    const width = this.stdout.columns
-    const height = this.stdout.rows
-    if (width > 0 && height > 0) this.handleResize(width, height)
+    this.handleResize()
   }).bind(this)
   private _capabilities: TerminalCapabilities | null = null
   private _latestPointer: { x: number; y: number } = { x: 0, y: 0 }
@@ -3907,10 +3905,18 @@ export class CliRenderer extends EventEmitter implements RenderContext {
     }
   }
 
-  private handleResize(width: number, height: number): void {
+  private handleResize(): void {
     if (this._isDestroyed) return
+    const resize = () => {
+      const stdout = this.stdout as NodeJS.WriteStream & { _refreshSize?: () => void }
+      // PTY bridges can deliver SIGWINCH before the stream's cached dimensions reflect the new window size.
+      stdout._refreshSize?.()
+      const width = stdout.columns
+      const height = stdout.rows
+      if (width > 0 && height > 0) this.processResize(width, height)
+    }
     if (this._splitHeight > 0) {
-      this.processResize(width, height)
+      resize()
       return
     }
 
@@ -3921,7 +3927,7 @@ export class CliRenderer extends EventEmitter implements RenderContext {
 
     this.resizeTimeoutId = this.clock.setTimeout(() => {
       this.resizeTimeoutId = null
-      this.processResize(width, height)
+      resize()
     }, this.resizeDebounceDelay)
   }
 

--- a/packages/core/src/tests/renderer.clock.test.ts
+++ b/packages/core/src/tests/renderer.clock.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, expect, test } from "bun:test"
 import { SystemClock } from "../lib/clock.js"
 import { TextRenderable } from "../renderables/Text.js"
+import { CliRenderEvents } from "../renderer.js"
 import { createTestRenderer, type TestRenderer } from "../testing/test-renderer.js"
 import { ManualClock } from "../testing/manual-clock.js"
 
@@ -33,6 +34,25 @@ test("renderer init does not pre-schedule frames when size is unchanged", async 
   await Promise.resolve()
 
   expect(frameCalls).toBe(0)
+})
+
+test("SIGWINCH refreshes terminal dimensions after the resize debounce", () => {
+  const stdout = (renderer as unknown as { stdout: { columns: number; rows: number; _refreshSize?: () => void } })
+    .stdout
+  const dimensions: Array<[number, number]> = []
+  renderer.on(CliRenderEvents.RESIZE, (width, height) => dimensions.push([width, height]))
+  stdout._refreshSize = () => {
+    stdout.columns = 60
+    stdout.rows = 18
+  }
+
+  // @ts-expect-error - invoke the private signal handler in a regression test
+  renderer.sigwinchHandler()
+  clock.advance(100)
+
+  expect(renderer.width).toBe(60)
+  expect(renderer.height).toBe(18)
+  expect(dimensions).toEqual([[60, 18]])
 })
 
 test("requestRender() does not stall after a backward clock jump", async () => {

--- a/packages/core/src/tests/renderer.clock.test.ts
+++ b/packages/core/src/tests/renderer.clock.test.ts
@@ -77,6 +77,20 @@ test("SIGWINCH reads dimensions from a TTY stdin when stdout is piped", () => {
   expect(renderer.height).toBe(44)
 })
 
+test("SIGWINCH ignores invalid dimensions after refreshing", () => {
+  const stdout = (renderer as unknown as { stdout: { columns: number; rows: number; _refreshSize?: () => void } })
+    .stdout
+  const before = [renderer.width, renderer.height]
+  stdout._refreshSize = () => {
+    stdout.columns = 0
+    stdout.rows = 0
+  }
+  // @ts-expect-error - invoke the private signal handler in a regression test
+  renderer.sigwinchHandler()
+  clock.advance(100)
+  expect([renderer.width, renderer.height]).toEqual(before)
+})
+
 test("requestRender() does not stall after a backward clock jump", async () => {
   clock.setTime(10_000)
   // @ts-expect-error - inspect private renderer timing state in regression test

--- a/packages/core/src/tests/renderer.clock.test.ts
+++ b/packages/core/src/tests/renderer.clock.test.ts
@@ -55,6 +55,28 @@ test("SIGWINCH refreshes terminal dimensions after the resize debounce", () => {
   expect(dimensions).toEqual([[60, 18]])
 })
 
+test("SIGWINCH reads dimensions from a TTY stdin when stdout is piped", () => {
+  const streams = renderer as unknown as {
+    stdout: { columns?: number; rows?: number; isTTY?: boolean }
+    stdin: { columns?: number; rows?: number; isTTY?: boolean; _refreshSize?: () => void }
+  }
+  streams.stdout.isTTY = false
+  streams.stdout.columns = undefined
+  streams.stdout.rows = undefined
+  streams.stdin.isTTY = true
+  streams.stdin._refreshSize = () => {
+    streams.stdin.columns = 132
+    streams.stdin.rows = 44
+  }
+
+  // @ts-expect-error - invoke the private signal handler in a regression test
+  renderer.sigwinchHandler()
+  clock.advance(100)
+
+  expect(renderer.width).toBe(132)
+  expect(renderer.height).toBe(44)
+})
+
 test("requestRender() does not stall after a backward clock jump", async () => {
   clock.setTime(10_000)
   // @ts-expect-error - inspect private renderer timing state in regression test

--- a/packages/core/src/tests/renderer.console-startup.test.ts
+++ b/packages/core/src/tests/renderer.console-startup.test.ts
@@ -135,7 +135,10 @@ test("CliRenderer uses its shared clock for debounced resize", async () => {
   })
 
   renderer = result.renderer
-  ;(renderer as any).handleResize(70, 30)
+  const stdout = (renderer as unknown as { stdout: { columns: number; rows: number } }).stdout
+  stdout.columns = 70
+  stdout.rows = 30
+  ;(renderer as unknown as { handleResize: () => void }).handleResize()
 
   expect(renderer.width).toBe(40)
   expect(renderer.height).toBe(20)


### PR DESCRIPTION
## Summary

- refresh cached TTY dimensions when a debounced `SIGWINCH` is handled
- sample the refreshed dimensions when the debounce expires
- use `stdin` as the size source when it is the TTY and `stdout` is piped
- cover stale cached dimensions and piped-stdout setups with regression tests

Browser-hosted PTY bridges can deliver a resize signal before the runtime's cached `stdout.columns` and `stdout.rows` reflect the new kernel window size. The existing resize path captured those cached values immediately, so initial attach and shrink events could keep rendering at the previous width.

OpenTUI also always read dimensions from `stdout`, but some launchers pipe stdout while keeping stdin attached to the controlling terminal. In that setup the resize signal arrives, yet stdout has no terminal dimensions. The resize handler now refreshes and samples the active TTY stream after the debounce expires.

This keeps the existing debounce behavior and is related to anomalyco/opencode#42225.

Closes #1344

## Testing

- `bun run test:js` (5,397 passed, 23 skipped)
- `bun run test:js:node` with Node.js 26.4.0 (4,664 passed, 6 skipped)
- `bun run build:lib`
- `bun run fmt:check`
- `bun run lint`
- Linux PTY reproduction covering initial attach, grow, and shrink
