### PR TITLE
fix(native): enable focus tracking without DECRQM

### DIFF
--- a/packages/native/src/terminal.zig
+++ b/packages/native/src/terminal.zig
@@ -426,9 +426,7 @@ pub fn enableDetectedFeatures(self: *Terminal, tty: anytype, use_kitty_keyboard:
         try self.setBracketedPaste(tty, true);
     }
 
-    if (self.caps.focus_tracking) {
-        try self.setFocusTracking(tty, true);
-    }
+    try self.setFocusTracking(tty, true);
 
     // queryTerminalSend already enabled mode 2031 during normal startup.
     if (!self.state.color_scheme_updates) {

--- a/packages/native/src/tests/terminal_test.zig
+++ b/packages/native/src/tests/terminal_test.zig
@@ -1004,9 +1004,11 @@ test "isXtversionTmux - detects tmux from xtversion" {
     try testing.expect(term.isXtversionTmux());
 }
 
-// ============================================================================
+// =====================================================================}
+
 // GRAPHEME CURSOR POSITIONING CAPABILITY TESTS
-// ============================================================================
+// =====================================================================}
+
 
 test "processCapabilityResponse - tmux sets explicit_cursor_positioning" {
     var term: Terminal = .{};
@@ -1109,9 +1111,11 @@ test "processCapabilityResponse - XTGETTCAP Ms only establishes positive support
     try testing.expectEqual(Terminal.Osc52Support.unknown, unknown.osc52_support);
 }
 
-// ============================================================================
+// =====================================================================}
+
 // CLIPBOARD (OSC 52) TESTS
-// ============================================================================
+// =====================================================================}
+
 
 test "writeClipboard - generates basic OSC52 sequence" {
     if (builtin.os.tag == .windows) return error.SkipZigTest;
@@ -1774,6 +1778,21 @@ test "Ghostty width profile enables mode 2027 and remains stable after setup sta
     try term.enableDetectedFeatures(&writer, false);
     try testing.expectEqual(utf8.WidthMethod.unicode_wide, term.caps.unicode);
     try testing.expect(std.mem.find(u8, writer.getWritten(), ansi.ANSI.unicodeSet) != null);
+}
+
+test "enableDetectedFeatures - enables focus tracking without a DECRPM response" {
+    var env = std.process.Environ.Map.init(testing.allocator);
+    defer env.deinit();
+
+    var term = Terminal.init(.{ .env_map = &env });
+    var writer = TestWriter.init(testing.allocator);
+    defer writer.deinit();
+
+    try testing.expect(!term.caps.focus_tracking);
+    try term.enableDetectedFeatures(&writer, false);
+
+    try testing.expect(std.mem.find(u8, writer.getWritten(), ansi.ANSI.focusSet) != null);
+    try testing.expect(term.state.focus_tracking);
 }
 
 test "setMouseMode - enable without movement keeps click/drag only" {


### PR DESCRIPTION
## Summary

- enable focus tracking during normal feature activation even when DECRQM has no response
- keep the detected capability flag tied to an actual terminal response
- cover the no-DECRPM path with a native regression test

Some terminals, including Konsole, implement focus reporting but do not answer the `CSI ? 1004 $ p` query. Query silence therefore cannot be used as evidence that mode 1004 is unsupported. The renderer now requests the existing DEC private mode unconditionally, while the existing terminal state continues to own teardown and focus-in restoration.

The compatibility assumption is that terminals without mode 1004 support ignore the unknown DECSET sequence, matching normal DEC private-mode behavior. No configuration default or public interface changes.

Closes #1333

## Testing

- filtered Zig 0.16 native tests: 2 passed
- full Zig 0.16 native suite: 2,013 passed, 8 skipped
- native hello example
- `bun run build`
- `bun run fmt:check`
- `bun run lint`
- `zig fmt --check packages/native/src/terminal.zig packages/native/src/tests/terminal_test.zig`
- `git diff --check`
