### PR TITLE
feat(native): allow line wrapping between CJK characters

### DIFF
--- a/packages/core/src/tests/wrap-resize-perf.test.ts
+++ b/packages/core/src/tests/wrap-resize-perf.test.ts
@@ -79,6 +79,45 @@ describe("Word wrap algorithmic complexity", () => {
   const COMPLEXITY_THRESHOLD = 1.75
   const MEASURE_WIDTHS = [76, 77, 78, 79, 80, 81, 82, 83]
 
+  it("a split grapheme does not disable ASCII fitting for the remaining word", () => {
+    const control = TextBuffer.create("wcwidth")
+    const split = TextBuffer.create("wcwidth")
+    const controlView = TextBufferView.create(control)
+    const splitView = TextBufferView.create(split)
+    try {
+      for (const buffer of [control, split]) {
+        buffer.setText("\u{1f44b}")
+        buffer.append(buffer === split ? "\u{1f3fb}" : "\u{1f44b}")
+        buffer.append("x".repeat(64000))
+        buffer.append("y")
+      }
+      controlView.setWrapMode("word")
+      splitView.setWrapMode("word")
+      for (const width of MEASURE_WIDTHS) {
+        expect(splitView.measureForDimensions(width, 100)).toEqual(controlView.measureForDimensions(width, 100))
+      }
+      const controlMeasure = (width: number) => {
+        controlView.measureForDimensions(width, 100)
+      }
+      const rounds = calibrateRoundsPerSample(controlMeasure, MEASURE_WIDTHS)
+      const ratio = measureMedianRatio(
+        controlMeasure,
+        (width) => {
+          splitView.measureForDimensions(width, 100)
+        },
+        MEASURE_WIDTHS,
+        rounds,
+      )
+      // The shared ASCII suffix must not inherit the prefix's scalar Unicode scan.
+      expect(ratio).toBeLessThan(5)
+    } finally {
+      splitView.destroy()
+      controlView.destroy()
+      split.destroy()
+      control.destroy()
+    }
+  })
+
   it("should have O(n) complexity for word wrap without word breaks", () => {
     const smallSize = 20000
     const largeSize = 40000

--- a/packages/core/src/text-buffer-view.test.ts
+++ b/packages/core/src/text-buffer-view.test.ts
@@ -3,6 +3,82 @@ import { TextBuffer } from "./text-buffer.js"
 import { TextBufferView } from "./text-buffer-view.js"
 import { StyledText, stringToStyledText } from "./lib/styled-text.js"
 import { RGBA } from "./lib/RGBA.js"
+import { OptimizedBuffer } from "./buffer.js"
+
+for (const method of ["unicode", "wcwidth"] as const) {
+  for (const [name, left, right, cluster, width] of [
+    ["emoji modifier", "\u65e5\u672c\u{1f44b}", "\u{1f3fb}\u8a9e\u6587", "\u{1f44b}\u{1f3fb}", 4],
+    ["ZWJ sequence", "\u65e5\u672c\u{1f469}\u200d", "\u{1f4bb}\u8a9e\u6587", "\u{1f469}\u200d\u{1f4bb}", 4],
+    [
+      "modifier and ZWJ",
+      "\u65e5\u672c\u{1f469}",
+      "\u{1f3fb}\u200d\u{1f4bb}\u8a9e\u6587",
+      "\u{1f469}\u{1f3fb}\u200d\u{1f4bb}",
+      6,
+    ],
+    ["combining cluster control", "\u65e5\u672ca\u0301", "\u8a9e\u6587", "a\u0301", 4],
+  ] as const) {
+    it(`word wrapping keeps an appended ${name} with its base (${method})`, () => {
+      const buffer = TextBuffer.create(method)
+      const view = TextBufferView.create(buffer)
+      const screen = OptimizedBuffer.create(8, 8, method)
+      try {
+        buffer.setText(left)
+        buffer.append(right)
+        view.setWrapMode("word")
+        view.setWrapWidth(width)
+        screen.clear()
+        screen.drawTextBuffer(view, 0, 0)
+        const rows = new TextDecoder()
+          .decode(screen.getRealCharBytes(true))
+          .split("\n")
+          .map((row) => row.trimEnd())
+          .filter(Boolean)
+        expect(rows.join("")).toBe(left + right)
+        if (name !== "combining cluster control") expect(view.lineInfo.lineStartCols).not.toContain(6)
+        expect(rows.some((row) => row.includes(cluster))).toBe(true)
+      } finally {
+        screen.destroy()
+        view.destroy()
+        buffer.destroy()
+      }
+    })
+  }
+}
+
+it("cached word and CJK breaks retain streaming source order", () => {
+  const part = "AB \u65e5\u672c\u3002\u8a9e\u6587 "
+  const layouts = []
+  for (const fragmented of [false, true]) {
+    const buffer = TextBuffer.create("wcwidth")
+    const view = TextBufferView.create(buffer)
+    const screen = OptimizedBuffer.create(10, 256, "wcwidth")
+    try {
+      if (fragmented) {
+        for (let i = 0; i < 64; i++) buffer.append(part)
+      } else {
+        buffer.setText(part.repeat(64))
+      }
+      view.setWrapMode("word")
+      for (const width of [6, 8, 6]) {
+        view.setWrapWidth(width)
+        screen.clear()
+        screen.drawTextBuffer(view, 0, 0)
+        const lines = view.lineInfo
+        layouts.push({
+          rows: new TextDecoder().decode(screen.getRealCharBytes(true)),
+          starts: lines.lineStartCols,
+          widths: lines.lineWidthCols,
+        })
+      }
+    } finally {
+      screen.destroy()
+      view.destroy()
+      buffer.destroy()
+    }
+  }
+  expect(layouts.slice(0, 3)).toEqual(layouts.slice(3))
+})
 
 describe("TextBufferView", () => {
   let buffer: TextBuffer

--- a/packages/core/src/text-buffer-view.test.ts
+++ b/packages/core/src/text-buffer-view.test.ts
@@ -80,6 +80,85 @@ it("cached word and CJK breaks retain streaming source order", () => {
   expect(layouts.slice(0, 3)).toEqual(layouts.slice(3))
 })
 
+for (const method of ["unicode", "unicode-wide", "wcwidth"] as const) {
+  for (const [name, parts, width, expectedRows] of [
+    [
+      "split flags",
+      ["\u65e5\u672c\u{1f1fa}", "\u{1f1f8}\u{1f1fa}\u{1f1f8}\u8a9e\u6587"],
+      4,
+      ["\u65e5", "\u672c\u{1f1fa}\u{1f1f8}", "\u{1f1fa}\u{1f1f8}\u8a9e", "\u6587"],
+    ],
+    ["zero-width chunk between indicators", ["\u{1f1e6}", "\u0301", "\u{1f1e7}"], 1, ["\u{1f1e6}", "\u{1f1e7}"]],
+    [
+      "RI state across three chunks",
+      ["\u672c\u{1f1e6}", "\u{1f1e7}\u{1f1e8}", "\u{1f1e9}\u{1f1ea}\u{1f1eb}"],
+      3,
+      ["\u672c", "\u{1f1e6}\u{1f1e7}", "\u{1f1e8}\u{1f1e9}", "\u{1f1ea}\u{1f1eb}"],
+    ],
+    ["leading whitespace after a zero-width chunk", ["\u0301", " x"], 4, [" x"]],
+    ["kana punctuation", ["AB \u30ab", "\u30fb\u30ca"], 6, ["AB", "\u30ab\u30fb\u30ca"]],
+  ] as const) {
+    it(`word wrapping preserves ${name} across appends (${method})`, () => {
+      const buffer = TextBuffer.create(method)
+      const view = TextBufferView.create(buffer)
+      const screen = OptimizedBuffer.create(width + 1, 8, method)
+      try {
+        for (const part of parts) buffer.append(part)
+        view.setWrapMode("word")
+        for (const wrapWidth of [width, width + 1, width]) {
+          view.setWrapWidth(wrapWidth)
+          const measure = view.measureForDimensions(wrapWidth, 8)
+          const lines = view.lineInfo
+          expect(Math.max(...lines.lineWidthCols)).toBeLessThanOrEqual(wrapWidth)
+          expect(measure).toEqual({
+            lineCount: lines.lineWidthCols.length,
+            widthColsMax: Math.max(...lines.lineWidthCols),
+          })
+        }
+        screen.clear()
+        screen.drawTextBuffer(view, 0, 0)
+        const rows = new TextDecoder()
+          .decode(screen.getRealCharBytes(true))
+          .split("\n")
+          .map((row) => row.trimEnd())
+          .filter(Boolean)
+        expect(rows).toEqual([...expectedRows])
+        expect(buffer.getPlainText()).toBe(parts.join(""))
+      } finally {
+        screen.destroy()
+        view.destroy()
+        buffer.destroy()
+      }
+    })
+  }
+}
+
+for (const method of ["unicode", "unicode-wide"] as const) {
+  for (const [base, mark, suffix] of [
+    ["\u304b", "\u3099", "\u304f"],
+    ["\u306f", "\u309a", "\u3072"],
+  ]) {
+    it(`word wrapping retains an appended kana mark (${method}, ${mark.codePointAt(0)})`, () => {
+      const buffer = TextBuffer.create(method)
+      const view = TextBufferView.create(buffer)
+      const screen = OptimizedBuffer.create(8, 2, method)
+      try {
+        buffer.setText(base)
+        buffer.append(mark + suffix)
+        view.setWrapMode("word")
+        view.setWrapWidth(8)
+        screen.clear()
+        screen.drawTextBuffer(view, 0, 0)
+        expect(new TextDecoder().decode(screen.getRealCharBytes(true)).trim()).toBe(base + mark + suffix)
+      } finally {
+        screen.destroy()
+        view.destroy()
+        buffer.destroy()
+      }
+    })
+  }
+}
+
 describe("TextBufferView", () => {
   let buffer: TextBuffer
   let view: TextBufferView

--- a/packages/core/src/text-buffer-view.test.ts
+++ b/packages/core/src/text-buffer-view.test.ts
@@ -5,47 +5,6 @@ import { StyledText, stringToStyledText } from "./lib/styled-text.js"
 import { RGBA } from "./lib/RGBA.js"
 import { OptimizedBuffer } from "./buffer.js"
 
-for (const method of ["unicode", "wcwidth"] as const) {
-  for (const [name, left, right, cluster, width] of [
-    ["emoji modifier", "\u65e5\u672c\u{1f44b}", "\u{1f3fb}\u8a9e\u6587", "\u{1f44b}\u{1f3fb}", 4],
-    ["ZWJ sequence", "\u65e5\u672c\u{1f469}\u200d", "\u{1f4bb}\u8a9e\u6587", "\u{1f469}\u200d\u{1f4bb}", 4],
-    [
-      "modifier and ZWJ",
-      "\u65e5\u672c\u{1f469}",
-      "\u{1f3fb}\u200d\u{1f4bb}\u8a9e\u6587",
-      "\u{1f469}\u{1f3fb}\u200d\u{1f4bb}",
-      6,
-    ],
-    ["combining cluster control", "\u65e5\u672ca\u0301", "\u8a9e\u6587", "a\u0301", 4],
-  ] as const) {
-    it(`word wrapping keeps an appended ${name} with its base (${method})`, () => {
-      const buffer = TextBuffer.create(method)
-      const view = TextBufferView.create(buffer)
-      const screen = OptimizedBuffer.create(8, 8, method)
-      try {
-        buffer.setText(left)
-        buffer.append(right)
-        view.setWrapMode("word")
-        view.setWrapWidth(width)
-        screen.clear()
-        screen.drawTextBuffer(view, 0, 0)
-        const rows = new TextDecoder()
-          .decode(screen.getRealCharBytes(true))
-          .split("\n")
-          .map((row) => row.trimEnd())
-          .filter(Boolean)
-        expect(rows.join("")).toBe(left + right)
-        if (name !== "combining cluster control") expect(view.lineInfo.lineStartCols).not.toContain(6)
-        expect(rows.some((row) => row.includes(cluster))).toBe(true)
-      } finally {
-        screen.destroy()
-        view.destroy()
-        buffer.destroy()
-      }
-    })
-  }
-}
-
 it("cached word and CJK breaks retain streaming source order", () => {
   const part = "AB \u65e5\u672c\u3002\u8a9e\u6587 "
   const layouts = []
@@ -83,19 +42,41 @@ it("cached word and CJK breaks retain streaming source order", () => {
 for (const method of ["unicode", "unicode-wide", "wcwidth"] as const) {
   for (const [name, parts, width, expectedRows] of [
     [
-      "split flags",
+      "mixed CJK and split flags using the existing word policy",
       ["\u65e5\u672c\u{1f1fa}", "\u{1f1f8}\u{1f1fa}\u{1f1f8}\u8a9e\u6587"],
       4,
-      ["\u65e5", "\u672c\u{1f1fa}\u{1f1f8}", "\u{1f1fa}\u{1f1f8}\u8a9e", "\u6587"],
+      ["\u65e5\u672c", "\u{1f1fa}\u{1f1f8}\u{1f1fa}\u{1f1f8}", "\u8a9e\u6587"],
     ],
-    ["zero-width chunk between indicators", ["\u{1f1e6}", "\u0301", "\u{1f1e7}"], 1, ["\u{1f1e6}", "\u{1f1e7}"]],
     [
-      "RI state across three chunks",
-      ["\u672c\u{1f1e6}", "\u{1f1e7}\u{1f1e8}", "\u{1f1e9}\u{1f1ea}\u{1f1eb}"],
+      "non-CJK chunk-local flag boundaries",
+      ["\u{1f1e6}", "\u{1f1e7}\u{1f1e8}", "\u{1f1e9}\u{1f1ea}\u{1f1eb}"],
       3,
-      ["\u672c", "\u{1f1e6}\u{1f1e7}", "\u{1f1e8}\u{1f1e9}", "\u{1f1ea}\u{1f1eb}"],
+      ["\u{1f1e6}\u{1f1e7}\u{1f1e8}", "\u{1f1e9}\u{1f1ea}\u{1f1eb}"],
     ],
-    ["leading whitespace after a zero-width chunk", ["\u0301", " x"], 4, [" x"]],
+    [
+      "mixed CJK and a split modifier using the existing word policy",
+      ["\u65e5\u672c\u{1f44b}", "\u{1f3fb}\u8a9e\u6587"],
+      4,
+      ["\u65e5\u672c", "\u{1f44b}\u{1f3fb}", "\u8a9e\u6587"],
+    ],
+    [
+      "mixed CJK and a split ZWJ using the existing word policy",
+      ["\u65e5\u672c\u{1f469}\u200d", "\u{1f4bb}\u8a9e\u6587"],
+      4,
+      ["\u65e5\u672c", "\u{1f469}\u200d\u{1f4bb}", "\u8a9e\u6587"],
+    ],
+    [
+      "existing modifier and ZWJ limitations",
+      ["\u65e5\u672c\u{1f469}", "\u{1f3fb}\u200d\u{1f4bb}\u8a9e\u6587"],
+      6,
+      ["\u65e5\u672c\u{1f469}", "\u{1f3fb}\u200d\u{1f4bb}\u8a9e", "\u6587"],
+    ],
+    [
+      "CJK opportunities on logical lines following an unsafe line",
+      ["\u65e5\u672c\u{1f44b}", "\u{1f3fb}\u8a9e\u6587\n\nA \u65e5\u672c\u8a9e"],
+      4,
+      ["\u65e5\u672c", "\u{1f44b}\u{1f3fb}", "\u8a9e\u6587", "A \u65e5", "\u672c\u8a9e"],
+    ],
     ["kana punctuation", ["AB \u30ab", "\u30fb\u30ca"], 6, ["AB", "\u30ab\u30fb\u30ca"]],
   ] as const) {
     it(`word wrapping preserves ${name} across appends (${method})`, () => {

--- a/packages/native/src/buffer.zig
+++ b/packages/native/src/buffer.zig
@@ -1751,21 +1751,17 @@ pub const OptimizedBuffer = struct {
                 }
 
                 text_buffer_loop: while (byte_offset < byte_end and col < col_end) {
-                    const at_special = special_idx < render_clusters.len and render_clusters[special_idx].byte_start <= byte_offset;
+                    const at_special = special_idx < render_clusters.len and render_clusters[special_idx].byte_start == byte_offset;
 
                     var grapheme_bytes: []const u8 = undefined;
                     var cluster_width_cols: u32 = undefined;
 
                     if (at_special) {
                         const g = render_clusters[special_idx];
-                        const end = @min(g.byte_start + g.byte_len, byte_end);
-                        grapheme_bytes = chunk_bytes[byte_offset..end];
-                        // Cross-chunk RI parity can place a global boundary inside a cached pair.
-                        cluster_width_cols = if (byte_offset == g.byte_start and end == g.byte_start + g.byte_len)
-                            g.width_cols
-                        else
-                            utf8.calculateTextWidth(grapheme_bytes, text_buffer.tabWidth(), false, text_buffer.widthMethod());
-                        byte_offset = end;
+                        if (g.byte_start + g.byte_len > byte_end) break;
+                        grapheme_bytes = chunk_bytes[g.byte_start .. g.byte_start + g.byte_len];
+                        cluster_width_cols = g.width_cols;
+                        byte_offset = g.byte_start + g.byte_len;
                         special_idx += 1;
                     } else {
                         if (byte_offset >= byte_end or byte_offset >= chunk_bytes.len) break;

--- a/packages/native/src/buffer.zig
+++ b/packages/native/src/buffer.zig
@@ -1751,17 +1751,21 @@ pub const OptimizedBuffer = struct {
                 }
 
                 text_buffer_loop: while (byte_offset < byte_end and col < col_end) {
-                    const at_special = special_idx < render_clusters.len and render_clusters[special_idx].byte_start == byte_offset;
+                    const at_special = special_idx < render_clusters.len and render_clusters[special_idx].byte_start <= byte_offset;
 
                     var grapheme_bytes: []const u8 = undefined;
                     var cluster_width_cols: u32 = undefined;
 
                     if (at_special) {
                         const g = render_clusters[special_idx];
-                        if (g.byte_start + g.byte_len > byte_end) break;
-                        grapheme_bytes = chunk_bytes[g.byte_start .. g.byte_start + g.byte_len];
-                        cluster_width_cols = g.width_cols;
-                        byte_offset = g.byte_start + g.byte_len;
+                        const end = @min(g.byte_start + g.byte_len, byte_end);
+                        grapheme_bytes = chunk_bytes[byte_offset..end];
+                        // Cross-chunk RI parity can place a global boundary inside a cached pair.
+                        cluster_width_cols = if (byte_offset == g.byte_start and end == g.byte_start + g.byte_len)
+                            g.width_cols
+                        else
+                            utf8.calculateTextWidth(grapheme_bytes, text_buffer.tabWidth(), false, text_buffer.widthMethod());
+                        byte_offset = end;
                         special_idx += 1;
                     } else {
                         if (byte_offset >= byte_end or byte_offset >= chunk_bytes.len) break;

--- a/packages/native/src/edit-buffer.zig
+++ b/packages/native/src/edit-buffer.zig
@@ -821,14 +821,14 @@ pub const EditBuffer = struct {
             if (seg.isBreak() or seg.isLineStart()) break;
             if (seg.asText()) |chunk| {
                 const next_cols = cols_before + chunk.width_cols;
-                const layout = self.tb.getLayoutInfoFor(chunk) catch {
+                const layout = self.tb.getWordLayoutInfoFor(chunk) catch {
                     cols_before = next_cols;
                     passed_cursor = passed_cursor or cursor.col < next_cols;
                     previous_word_class = .other;
                     continue;
                 };
 
-                if (utf8.isCjkAsciiTransition(previous_word_class, layout.word_classes.first) and
+                if (utf8.isCjkAsciiTransition(previous_word_class, layout.first_class) and
                     cols_before > cursor.col and cols_before <= line_width)
                 {
                     const offset = iter_mod.coordsToOffset(self.tb.rope(), cursor.row, cols_before) orelse cursor.offset;
@@ -843,7 +843,6 @@ pub const EditBuffer = struct {
                     const local_cursor_col = if (cursor.col > cols_before) cursor.col - cols_before else 0;
 
                     for (wrap_breaks) |wrap_break| {
-                        if (!wrap_break.kind.isWordBoundary()) continue;
                         const break_col = wrap_break.col_start;
                         const target_col = cols_before + wrap_break.colEnd();
 
@@ -877,7 +876,7 @@ pub const EditBuffer = struct {
                     // Mark that we've processed/passed the cursor position
                     passed_cursor = true;
                 }
-                previous_word_class = layout.word_classes.last;
+                previous_word_class = layout.last_class;
                 cols_before = next_cols;
             }
         }
@@ -909,25 +908,24 @@ pub const EditBuffer = struct {
             if (seg.asText()) |chunk| {
                 const next_cols = cols_before + chunk.width_cols;
 
-                const layout = self.tb.getLayoutInfoFor(chunk) catch {
+                const layout = self.tb.getWordLayoutInfoFor(chunk) catch {
                     cols_before = next_cols;
                     previous_word_class = .other;
                     continue;
                 };
 
-                if (utf8.isCjkAsciiTransition(previous_word_class, layout.word_classes.first) and cols_before < cursor.col) {
+                if (utf8.isCjkAsciiTransition(previous_word_class, layout.first_class) and cols_before < cursor.col) {
                     last_boundary = cols_before;
                 }
 
                 for (layout.wrap_breaks) |wrap_break| {
-                    if (!wrap_break.kind.isWordBoundary()) continue;
                     const boundary_col = cols_before + wrap_break.colEnd();
                     if (boundary_col < cursor.col) {
                         last_boundary = boundary_col;
                     }
                 }
 
-                previous_word_class = layout.word_classes.last;
+                previous_word_class = layout.last_class;
                 cols_before = next_cols;
                 if (cursor.col <= cols_before) break;
             }

--- a/packages/native/src/edit-buffer.zig
+++ b/packages/native/src/edit-buffer.zig
@@ -828,7 +828,7 @@ pub const EditBuffer = struct {
                     continue;
                 };
 
-                if (utf8.isCjkAsciiTransition(previous_word_class, layout.first_class) and
+                if (utf8.isCjkAsciiTransition(previous_word_class, layout.word_classes.first) and
                     cols_before > cursor.col and cols_before <= line_width)
                 {
                     const offset = iter_mod.coordsToOffset(self.tb.rope(), cursor.row, cols_before) orelse cursor.offset;
@@ -876,7 +876,7 @@ pub const EditBuffer = struct {
                     // Mark that we've processed/passed the cursor position
                     passed_cursor = true;
                 }
-                previous_word_class = layout.last_class;
+                previous_word_class = layout.word_classes.last;
                 cols_before = next_cols;
             }
         }
@@ -914,7 +914,7 @@ pub const EditBuffer = struct {
                     continue;
                 };
 
-                if (utf8.isCjkAsciiTransition(previous_word_class, layout.first_class) and cols_before < cursor.col) {
+                if (utf8.isCjkAsciiTransition(previous_word_class, layout.word_classes.first) and cols_before < cursor.col) {
                     last_boundary = cols_before;
                 }
 
@@ -925,7 +925,7 @@ pub const EditBuffer = struct {
                     }
                 }
 
-                previous_word_class = layout.last_class;
+                previous_word_class = layout.word_classes.last;
                 cols_before = next_cols;
                 if (cursor.col <= cols_before) break;
             }

--- a/packages/native/src/edit-buffer.zig
+++ b/packages/native/src/edit-buffer.zig
@@ -843,6 +843,7 @@ pub const EditBuffer = struct {
                     const local_cursor_col = if (cursor.col > cols_before) cursor.col - cols_before else 0;
 
                     for (wrap_breaks) |wrap_break| {
+                        if (!wrap_break.kind.isWordBoundary()) continue;
                         const break_col = wrap_break.col_start;
                         const target_col = cols_before + wrap_break.colEnd();
 
@@ -919,6 +920,7 @@ pub const EditBuffer = struct {
                 }
 
                 for (layout.wrap_breaks) |wrap_break| {
+                    if (!wrap_break.kind.isWordBoundary()) continue;
                     const boundary_col = cols_before + wrap_break.colEnd();
                     if (boundary_col < cursor.col) {
                         last_boundary = boundary_col;

--- a/packages/native/src/tests/edit-buffer_test.zig
+++ b/packages/native/src/tests/edit-buffer_test.zig
@@ -392,6 +392,27 @@ test "EditBuffer - combining mark keeps word class across chunks" {
     try std.testing.expectEqual(@as(u32, 1), eb.getPrevWordBoundary().col);
 }
 
+test "EditBuffer - word boundary treats CJK run as one word" {
+    const pool = gp.initGlobalPool(std.testing.allocator);
+    defer gp.deinitGlobalPool();
+    const link_pool = link.initGlobalLinkPool(std.testing.allocator);
+    defer link.deinitGlobalLinkPool();
+
+    var eb = try EditBuffer.init(std.testing.allocator, pool, link_pool, .wcwidth, null);
+    defer eb.deinit();
+
+    // Intercharacter wrap opportunities must not step word motion per character.
+    try eb.setText("日本語文字");
+
+    try eb.setCursor(0, 0);
+    const next_cursor = eb.getNextWordBoundary();
+    try std.testing.expectEqual(@as(u32, 10), next_cursor.col);
+
+    try eb.setCursor(0, 10);
+    const prev_cursor = eb.getPrevWordBoundary();
+    try std.testing.expectEqual(@as(u32, 0), prev_cursor.col);
+}
+
 test "EditBuffer - word boundary keeps Hangul run grouped" {
     const pool = gp.initGlobalPool(std.testing.allocator);
     defer gp.deinitGlobalPool();

--- a/packages/native/src/tests/text-buffer-drawing_test.zig
+++ b/packages/native/src/tests/text-buffer-drawing_test.zig
@@ -364,7 +364,7 @@ test "drawTextBuffer - issue 799 CJK word wrap has no duplicated glyphs" {
         "在aber (“但”)引入的转折从句前表示让步：虽然，的确",
         .word,
         15,
-        &.{ "在aber (“但”)", "引入的转折从句", "前表示让步：", "虽然，的确" },
+        &.{ "在aber (“但”)引", "入的转折从句前", "表示让步：虽", "然，的确" },
         null,
     );
 }

--- a/packages/native/src/tests/text-buffer-drawing_test.zig
+++ b/packages/native/src/tests/text-buffer-drawing_test.zig
@@ -96,6 +96,35 @@ test "drawTextBuffer - exact CJK and issue 609 wrapped rows" {
     }
 }
 
+test "drawTextBuffer - global RI boundaries preserve cached suffix clusters" {
+    const pool = gp.initGlobalPool(std.testing.allocator);
+    defer gp.deinitGlobalPool();
+    const link_pool = link.initGlobalLinkPool(std.testing.allocator);
+    defer link.deinitGlobalLinkPool();
+    var tb = try TextBuffer.init(std.testing.allocator, pool, link_pool, .unicode);
+    defer tb.deinit();
+    var view = try TextBufferView.init(std.testing.allocator, tb);
+    defer view.deinit();
+    view.setWrapMode(.word);
+    view.setWrapWidth(4);
+    var screen = try OptimizedBuffer.init(std.testing.allocator, 4, 3, .{ .pool = pool, .width_method = .unicode });
+    defer screen.deinit();
+    for ([_]struct { suffix: []const u8, row: []const u8, x: u32, y: u32 }{
+        .{ .suffix = "\u{1f1e7}\u{1f1e8}\u{1f1e9}\u{1f469}\u{200d}\u{1f4bb}x", .row = "\u{1f1e8}\u{1f1e9}\u{1f469}\u{200d}\u{1f4bb}", .x = 0, .y = 2 },
+        .{ .suffix = "\u{1f1e7}\u{1f1e8}\u{0301}x", .row = "\u{1f1e8}\u{0301}x", .x = 1, .y = 1 },
+    }) |case| {
+        try tb.setText("\u{672c}\u{1f1e6}");
+        try tb.append(case.suffix);
+        screen.clear(ansi.rgbaFromFloats(0.0, 0.0, 0.0, 1.0), 32);
+        screen.drawTextBuffer(view, 0, 0);
+        const row = try resolvedRow(std.testing.allocator, screen, pool, 1);
+        defer std.testing.allocator.free(row);
+        try std.testing.expectEqualStrings(case.row, std.mem.trimEnd(u8, row, " "));
+        if (case.y == 2) try std.testing.expect(gp.isContinuationChar(screen.get(3, 1).?.char));
+        try std.testing.expectEqual(@as(u32, 'x'), screen.get(case.x, case.y).?.char);
+    }
+}
+
 test "drawTextBuffer - streaming Prepend before ASCII vector is preserved" {
     const pool = gp.initGlobalPool(std.testing.allocator);
     defer gp.deinitGlobalPool();

--- a/packages/native/src/tests/text-buffer-drawing_test.zig
+++ b/packages/native/src/tests/text-buffer-drawing_test.zig
@@ -96,35 +96,6 @@ test "drawTextBuffer - exact CJK and issue 609 wrapped rows" {
     }
 }
 
-test "drawTextBuffer - global RI boundaries preserve cached suffix clusters" {
-    const pool = gp.initGlobalPool(std.testing.allocator);
-    defer gp.deinitGlobalPool();
-    const link_pool = link.initGlobalLinkPool(std.testing.allocator);
-    defer link.deinitGlobalLinkPool();
-    var tb = try TextBuffer.init(std.testing.allocator, pool, link_pool, .unicode);
-    defer tb.deinit();
-    var view = try TextBufferView.init(std.testing.allocator, tb);
-    defer view.deinit();
-    view.setWrapMode(.word);
-    view.setWrapWidth(4);
-    var screen = try OptimizedBuffer.init(std.testing.allocator, 4, 3, .{ .pool = pool, .width_method = .unicode });
-    defer screen.deinit();
-    for ([_]struct { suffix: []const u8, row: []const u8, x: u32, y: u32 }{
-        .{ .suffix = "\u{1f1e7}\u{1f1e8}\u{1f1e9}\u{1f469}\u{200d}\u{1f4bb}x", .row = "\u{1f1e8}\u{1f1e9}\u{1f469}\u{200d}\u{1f4bb}", .x = 0, .y = 2 },
-        .{ .suffix = "\u{1f1e7}\u{1f1e8}\u{0301}x", .row = "\u{1f1e8}\u{0301}x", .x = 1, .y = 1 },
-    }) |case| {
-        try tb.setText("\u{672c}\u{1f1e6}");
-        try tb.append(case.suffix);
-        screen.clear(ansi.rgbaFromFloats(0.0, 0.0, 0.0, 1.0), 32);
-        screen.drawTextBuffer(view, 0, 0);
-        const row = try resolvedRow(std.testing.allocator, screen, pool, 1);
-        defer std.testing.allocator.free(row);
-        try std.testing.expectEqualStrings(case.row, std.mem.trimEnd(u8, row, " "));
-        if (case.y == 2) try std.testing.expect(gp.isContinuationChar(screen.get(3, 1).?.char));
-        try std.testing.expectEqual(@as(u32, 'x'), screen.get(case.x, case.y).?.char);
-    }
-}
-
 test "drawTextBuffer - streaming Prepend before ASCII vector is preserved" {
     const pool = gp.initGlobalPool(std.testing.allocator);
     defer gp.deinitGlobalPool();

--- a/packages/native/src/tests/text-buffer-segment_test.zig
+++ b/packages/native/src/tests/text-buffer-segment_test.zig
@@ -101,6 +101,9 @@ test "TextChunk keeps CJK line opportunities out of the word cache" {
     const text = "\u{65e5}\u{672c}\t\u{8a9e}\u{6587}";
     const mem_id = try registry.register(text, false);
     var chunk: TextChunk = .{ .mem_id = mem_id, .byte_start = 0, .byte_end = text.len, .width_cols = 10 };
+    const initial_words = try chunk.getWordLayoutInfo(arena.allocator(), &cache, &registry, 2, .unicode);
+    try testing.expectEqual(@as(usize, 1), initial_words.wrap_breaks.len);
+    try testing.expectEqual(@as(usize, 0), chunk.cold.?.cjk_breaks.capacity);
     _ = try chunk.getLayoutInfo(arena.allocator(), &cache, &registry, 2, .unicode);
     try testing.expect(chunk.cold.?.wrap_breaks != null);
     for ([_]utf8.WidthMethod{ .unicode, .wcwidth }) |method| {
@@ -149,6 +152,10 @@ test "findChunkLayoutInfo classifies direct byte and column break metadata" {
         } },
         // Break after ideographic punctuation only; 。 must never start a line.
         .{ .text = "字。", .expected = &.{.{ .byte_start = 3, .col_start = 2, .byte_len = 3, .width_cols = 2, .kind = .punctuation }} },
+        .{ .text = "\u{30ab}\u{30fb}\u{30ca}", .expected = &.{.{ .byte_start = 3, .col_start = 2, .byte_len = 3, .width_cols = 2, .kind = .cjk_intercharacter }} },
+        .{ .text = "\u{30ab}\u{30a0}\u{30ca}", .expected = &.{.{ .byte_start = 3, .col_start = 2, .byte_len = 3, .width_cols = 2, .kind = .cjk_intercharacter }} },
+        .{ .text = "\u{304b}\u{3099}\u{304f}", .expected = &.{.{ .byte_start = 0, .col_start = 0, .byte_len = 6, .width_cols = 2, .kind = .cjk_intercharacter }} },
+        .{ .text = "\u{3099}\u{304f}", .expected = &.{} },
     };
 
     var breaks: std.ArrayListUnmanaged(utf8.LayoutWrapBreak) = .empty;

--- a/packages/native/src/tests/text-buffer-segment_test.zig
+++ b/packages/native/src/tests/text-buffer-segment_test.zig
@@ -102,6 +102,9 @@ test "TextChunk keeps CJK line opportunities out of the word cache" {
     const mem_id = try registry.register(text, false);
     var chunk: TextChunk = .{ .mem_id = mem_id, .byte_start = 0, .byte_end = text.len, .width_cols = 10 };
     const initial_words = try chunk.getWordLayoutInfo(arena.allocator(), &cache, &registry, 2, .unicode);
+    try testing.expect(@sizeOf(@TypeOf(initial_words)) < @sizeOf(utf8.ChunkLayoutInfo));
+    try testing.expectEqual(utf8.WordClass.cjk_word, initial_words.word_classes.first);
+    try testing.expectEqual(utf8.WordClass.cjk_word, initial_words.word_classes.last);
     try testing.expectEqual(@as(usize, 1), initial_words.wrap_breaks.len);
     try testing.expectEqual(@as(usize, 0), chunk.cold.?.cjk_breaks.capacity);
     _ = try chunk.getLayoutInfo(arena.allocator(), &cache, &registry, 2, .unicode);
@@ -116,6 +119,8 @@ test "TextChunk keeps CJK line opportunities out of the word cache" {
             try testing.expectEqual(@as(usize, 1), lines.wrap_breaks.len);
             try testing.expectEqual(@as(usize, 2), lines.cjk_breaks.len);
             const cached_words = try chunk.getWordLayoutInfo(arena.allocator(), &cache, &registry, tab_width, method);
+            try testing.expectEqual(utf8.WordClass.cjk_word, cached_words.word_classes.first);
+            try testing.expectEqual(utf8.WordClass.cjk_word, cached_words.word_classes.last);
             try testing.expectEqual(@intFromPtr(words.wrap_breaks.ptr), @intFromPtr(cached_words.wrap_breaks.ptr));
             try testing.expectEqual(@as(usize, 1), cached_words.wrap_breaks.len);
             try testing.expectEqual(@as(usize, 2), chunk.getCachedLayoutInfo(tab_width, method).?.cjk_breaks.len);

--- a/packages/native/src/tests/text-buffer-segment_test.zig
+++ b/packages/native/src/tests/text-buffer-segment_test.zig
@@ -12,9 +12,46 @@ test "TextChunk keeps cold cache state out of rope leaves" {
     try testing.expect(@sizeOf(TextChunk) <= 24);
 }
 
+test "TextChunk layout cache retries and releases partial allocations" {
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    var registry = MemRegistry.init(testing.allocator);
+    defer registry.deinit();
+    const text = "\u{65e5}\u{672c} " ** 512;
+    const mem_id = try registry.register(text, false);
+
+    for (0..3) |fail_index| {
+        var failing = testing.FailingAllocator.init(testing.allocator, .{
+            .fail_index = fail_index,
+            .resize_fail_index = 0,
+        });
+        var cache: seg_mod.ChunkLayoutCache = .{ .allocator = failing.allocator() };
+        defer cache.clear();
+        var chunk: TextChunk = .{ .mem_id = mem_id, .byte_start = 0, .byte_end = text.len, .width_cols = 2560 };
+
+        try testing.expectError(error.OutOfMemory, chunk.getLayoutInfo(arena.allocator(), &cache, &registry, 2, .unicode));
+        try testing.expect(chunk.getCachedLayoutInfo(2, .unicode) == null);
+        failing.fail_index = std.math.maxInt(usize);
+        const retried = try chunk.getLayoutInfo(arena.allocator(), &cache, &registry, 2, .unicode);
+        try testing.expectEqual(@as(usize, 512), retried.wrap_breaks.len);
+        try testing.expectEqual(@as(usize, 512), retried.cjk_breaks.len);
+        try testing.expectEqual(retried.cjk_breaks.ptr, chunk.getCachedLayoutInfo(2, .unicode).?.cjk_breaks.ptr);
+        cache.clear();
+        try testing.expect(chunk.getCachedLayoutInfo(2, .unicode) == null);
+        try testing.expectEqual(failing.allocated_bytes, failing.freed_bytes);
+
+        failing.fail_index = failing.alloc_index + fail_index;
+        try testing.expectError(error.OutOfMemory, chunk.getLayoutInfo(arena.allocator(), &cache, &registry, 2, .unicode));
+        cache.clear();
+        try testing.expectEqual(failing.allocated_bytes, failing.freed_bytes);
+    }
+}
+
 test "TextChunk.getLayoutInfo returns direct byte and column metadata" {
     var arena = std.heap.ArenaAllocator.init(testing.allocator);
     defer arena.deinit();
+    var cache: seg_mod.ChunkLayoutCache = .{ .allocator = testing.allocator };
+    defer cache.clear();
 
     var registry = MemRegistry.init(testing.allocator);
     defer registry.deinit();
@@ -28,14 +65,14 @@ test "TextChunk.getLayoutInfo returns direct byte and column metadata" {
         .width_cols = @intCast(utf8.calculateTextWidth(text, 2, false, .unicode)),
     };
 
-    const layout = try chunk.getLayoutInfo(arena.allocator(), &registry, 2, .unicode);
+    const layout = try chunk.getLayoutInfo(arena.allocator(), &cache, &registry, 2, .unicode);
     try testing.expectEqual(@as(usize, 1), layout.wrap_breaks.len);
     try testing.expectEqual(@as(u32, 6), layout.wrap_breaks[0].byte_start);
     try testing.expectEqual(@as(u32, 4), layout.wrap_breaks[0].col_start);
     try testing.expectEqual(@as(u32, 7), layout.wrap_breaks[0].byteEnd());
     try testing.expectEqual(@as(u32, 5), layout.wrap_breaks[0].colEnd());
 
-    const cached = try chunk.getLayoutInfo(arena.allocator(), &registry, 2, .unicode);
+    const cached = try chunk.getLayoutInfo(arena.allocator(), &cache, &registry, 2, .unicode);
     try testing.expectEqual(@intFromPtr(layout.wrap_breaks.ptr), @intFromPtr(cached.wrap_breaks.ptr));
 
     const zero_width_text = "a\u{200B}b";
@@ -46,7 +83,7 @@ test "TextChunk.getLayoutInfo returns direct byte and column metadata" {
         .byte_end = @intCast(zero_width_text.len),
         .width_cols = @intCast(utf8.calculateTextWidth(zero_width_text, 2, false, .unicode)),
     };
-    const zero_width_layout = try zero_width_chunk.getLayoutInfo(arena.allocator(), &registry, 2, .unicode);
+    const zero_width_layout = try zero_width_chunk.getLayoutInfo(arena.allocator(), &cache, &registry, 2, .unicode);
     try testing.expectEqual(@as(usize, 1), zero_width_layout.wrap_breaks.len);
     try testing.expectEqual(@as(u32, 1), zero_width_layout.wrap_breaks[0].byte_start);
     try testing.expectEqual(@as(u32, 3), zero_width_layout.wrap_breaks[0].byte_len);
@@ -57,23 +94,25 @@ test "TextChunk.getLayoutInfo returns direct byte and column metadata" {
 test "TextChunk keeps CJK line opportunities out of the word cache" {
     var arena = std.heap.ArenaAllocator.init(testing.allocator);
     defer arena.deinit();
+    var cache: seg_mod.ChunkLayoutCache = .{ .allocator = testing.allocator };
+    defer cache.clear();
     var registry = MemRegistry.init(testing.allocator);
     defer registry.deinit();
     const text = "\u{65e5}\u{672c}\t\u{8a9e}\u{6587}";
     const mem_id = try registry.register(text, false);
     var chunk: TextChunk = .{ .mem_id = mem_id, .byte_start = 0, .byte_end = text.len, .width_cols = 10 };
-    _ = try chunk.getLayoutInfo(arena.allocator(), &registry, 2, .unicode);
+    _ = try chunk.getLayoutInfo(arena.allocator(), &cache, &registry, 2, .unicode);
     try testing.expect(chunk.cold.?.wrap_breaks != null);
     for ([_]utf8.WidthMethod{ .unicode, .wcwidth }) |method| {
         for ([_]u8{ 2, 8 }) |tab_width| {
-            const words = try chunk.getWordLayoutInfo(arena.allocator(), &registry, tab_width, method);
+            const words = try chunk.getWordLayoutInfo(arena.allocator(), &cache, &registry, tab_width, method);
             try testing.expectEqual(@as(usize, 1), words.wrap_breaks.len);
             try testing.expectEqual(utf8.LayoutWrapBreakKind.whitespace, words.wrap_breaks[0].kind);
             try testing.expectEqual(@as(u32, tab_width), words.wrap_breaks[0].width_cols);
-            const lines = try chunk.getLayoutInfo(arena.allocator(), &registry, tab_width, method);
+            const lines = try chunk.getLayoutInfo(arena.allocator(), &cache, &registry, tab_width, method);
             try testing.expectEqual(@as(usize, 1), lines.wrap_breaks.len);
             try testing.expectEqual(@as(usize, 2), lines.cjk_breaks.len);
-            const cached_words = try chunk.getWordLayoutInfo(arena.allocator(), &registry, tab_width, method);
+            const cached_words = try chunk.getWordLayoutInfo(arena.allocator(), &cache, &registry, tab_width, method);
             try testing.expectEqual(@intFromPtr(words.wrap_breaks.ptr), @intFromPtr(cached_words.wrap_breaks.ptr));
             try testing.expectEqual(@as(usize, 1), cached_words.wrap_breaks.len);
             try testing.expectEqual(@as(usize, 2), chunk.getCachedLayoutInfo(tab_width, method).?.cjk_breaks.len);
@@ -82,7 +121,7 @@ test "TextChunk keeps CJK line opportunities out of the word cache" {
     const greek = "\u{3bb}-\u{3bb}";
     const greek_id = try registry.register(greek, false);
     var greek_chunk: TextChunk = .{ .mem_id = greek_id, .byte_start = 0, .byte_end = greek.len, .width_cols = 3 };
-    _ = try greek_chunk.getWordLayoutInfo(arena.allocator(), &registry, 2, .unicode);
+    _ = try greek_chunk.getWordLayoutInfo(arena.allocator(), &cache, &registry, 2, .unicode);
     try testing.expect(greek_chunk.getCachedLayoutInfo(2, .unicode) != null);
 }
 
@@ -206,6 +245,8 @@ test "walkChunkLayoutInfo stops streaming after visitor allocation failure" {
 test "TextChunk.getLayoutInfo refreshes tab-dependent metadata" {
     var arena = std.heap.ArenaAllocator.init(testing.allocator);
     defer arena.deinit();
+    var cache: seg_mod.ChunkLayoutCache = .{ .allocator = testing.allocator };
+    defer cache.clear();
 
     var registry = MemRegistry.init(testing.allocator);
     defer registry.deinit();
@@ -218,11 +259,11 @@ test "TextChunk.getLayoutInfo refreshes tab-dependent metadata" {
         .width_cols = 4,
     };
 
-    const first = try chunk.getLayoutInfo(arena.allocator(), &registry, 2, .unicode);
+    const first = try chunk.getLayoutInfo(arena.allocator(), &cache, &registry, 2, .unicode);
     try testing.expectEqual(@as(u32, 2), first.wrap_breaks[0].width_cols);
     const capacity_after_first = arena.queryCapacity();
 
-    const second = try chunk.getLayoutInfo(arena.allocator(), &registry, 8, .unicode);
+    const second = try chunk.getLayoutInfo(arena.allocator(), &cache, &registry, 8, .unicode);
     try testing.expectEqual(@as(u32, 8), second.wrap_breaks[0].width_cols);
     try testing.expectEqual(@intFromPtr(first.wrap_breaks.ptr), @intFromPtr(second.wrap_breaks.ptr));
     try testing.expectEqual(capacity_after_first, arena.queryCapacity());

--- a/packages/native/src/tests/text-buffer-segment_test.zig
+++ b/packages/native/src/tests/text-buffer-segment_test.zig
@@ -54,6 +54,38 @@ test "TextChunk.getLayoutInfo returns direct byte and column metadata" {
     try testing.expectEqual(@as(u32, 0), zero_width_layout.wrap_breaks[0].width_cols);
 }
 
+test "TextChunk keeps CJK line opportunities out of the word cache" {
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    var registry = MemRegistry.init(testing.allocator);
+    defer registry.deinit();
+    const text = "\u{65e5}\u{672c}\t\u{8a9e}\u{6587}";
+    const mem_id = try registry.register(text, false);
+    var chunk: TextChunk = .{ .mem_id = mem_id, .byte_start = 0, .byte_end = text.len, .width_cols = 10 };
+    _ = try chunk.getLayoutInfo(arena.allocator(), &registry, 2, .unicode);
+    try testing.expect(chunk.cold.?.wrap_breaks != null);
+    for ([_]utf8.WidthMethod{ .unicode, .wcwidth }) |method| {
+        for ([_]u8{ 2, 8 }) |tab_width| {
+            const words = try chunk.getWordLayoutInfo(arena.allocator(), &registry, tab_width, method);
+            try testing.expectEqual(@as(usize, 1), words.wrap_breaks.len);
+            try testing.expectEqual(utf8.LayoutWrapBreakKind.whitespace, words.wrap_breaks[0].kind);
+            try testing.expectEqual(@as(u32, tab_width), words.wrap_breaks[0].width_cols);
+            const lines = try chunk.getLayoutInfo(arena.allocator(), &registry, tab_width, method);
+            try testing.expectEqual(@as(usize, 1), lines.wrap_breaks.len);
+            try testing.expectEqual(@as(usize, 2), lines.cjk_breaks.len);
+            const cached_words = try chunk.getWordLayoutInfo(arena.allocator(), &registry, tab_width, method);
+            try testing.expectEqual(@intFromPtr(words.wrap_breaks.ptr), @intFromPtr(cached_words.wrap_breaks.ptr));
+            try testing.expectEqual(@as(usize, 1), cached_words.wrap_breaks.len);
+            try testing.expectEqual(@as(usize, 2), chunk.getCachedLayoutInfo(tab_width, method).?.cjk_breaks.len);
+        }
+    }
+    const greek = "\u{3bb}-\u{3bb}";
+    const greek_id = try registry.register(greek, false);
+    var greek_chunk: TextChunk = .{ .mem_id = greek_id, .byte_start = 0, .byte_end = greek.len, .width_cols = 3 };
+    _ = try greek_chunk.getWordLayoutInfo(arena.allocator(), &registry, 2, .unicode);
+    try testing.expect(greek_chunk.getCachedLayoutInfo(2, .unicode) != null);
+}
+
 test "findChunkLayoutInfo classifies direct byte and column break metadata" {
     const Case = struct {
         text: []const u8,

--- a/packages/native/src/tests/text-buffer-segment_test.zig
+++ b/packages/native/src/tests/text-buffer-segment_test.zig
@@ -71,6 +71,13 @@ test "findChunkLayoutInfo classifies direct byte and column break metadata" {
         .{ .text = "a\tb", .tab_width = 2, .expected = &.{.{ .byte_start = 1, .col_start = 1, .byte_len = 1, .width_cols = 2, .kind = .whitespace }} },
         .{ .text = "a\tb", .tab_width = 4, .expected = &.{.{ .byte_start = 1, .col_start = 1, .byte_len = 1, .width_cols = 4, .kind = .whitespace }} },
         .{ .text = "ab,cd", .expected = &.{.{ .byte_start = 2, .col_start = 2, .byte_len = 1, .width_cols = 1, .kind = .punctuation }} },
+        .{ .text = "中文", .expected = &.{.{ .byte_start = 0, .col_start = 0, .byte_len = 3, .width_cols = 2, .kind = .cjk_intercharacter }} },
+        .{ .text = "中文A", .expected = &.{
+            .{ .byte_start = 0, .col_start = 0, .byte_len = 3, .width_cols = 2, .kind = .cjk_intercharacter },
+            .{ .byte_start = 3, .col_start = 2, .byte_len = 3, .width_cols = 2, .kind = .script_transition },
+        } },
+        // Break after ideographic punctuation only; 。 must never start a line.
+        .{ .text = "字。", .expected = &.{.{ .byte_start = 3, .col_start = 2, .byte_len = 3, .width_cols = 2, .kind = .punctuation }} },
     };
 
     var breaks: std.ArrayListUnmanaged(utf8.LayoutWrapBreak) = .empty;

--- a/packages/native/src/tests/text-buffer-view_test.zig
+++ b/packages/native/src/tests/text-buffer-view_test.zig
@@ -1441,7 +1441,8 @@ test "TextBufferView word wrapping - fragmented ASCII CJK transition is a bounda
     view.setWrapMode(.word);
     view.setWrapWidth(5);
 
-    try std.testing.expectEqualSlices(u32, &.{ 3, 4 }, view.getCachedLineInfo().line_width_cols);
+    // "abc日" fills the first line; the CJK run may break between characters.
+    try std.testing.expectEqualSlices(u32, &.{ 5, 2 }, view.getCachedLineInfo().line_width_cols);
 }
 
 test "TextBufferView word wrapping - combining mark keeps base class across chunks" {
@@ -1466,7 +1467,78 @@ test "TextBufferView word wrapping - combining mark keeps base class across chun
 
     view.setWrapMode(.word);
     view.setWrapWidth(4);
-    try std.testing.expectEqualSlices(u32, &.{ 1, 4 }, view.getCachedLineInfo().line_width_cols);
+    // "a\u{0301}日" fills the first line; the CJK run may break between characters.
+    try std.testing.expectEqualSlices(u32, &.{ 3, 2 }, view.getCachedLineInfo().line_width_cols);
+}
+
+test "TextBufferView word wrapping - CJK run wraps between characters" {
+    const pool = gp.initGlobalPool(std.testing.allocator);
+    defer gp.deinitGlobalPool();
+    const link_pool = link.initGlobalLinkPool(std.testing.allocator);
+    defer link.deinitGlobalLinkPool();
+
+    var tb = try TextBuffer.init(std.testing.allocator, pool, link_pool, .wcwidth);
+    defer tb.deinit();
+    var view = try TextBufferView.init(std.testing.allocator, tb);
+    defer view.deinit();
+
+    // "AB" = 2 cols, space = 1 col, each CJK char = 2 cols.
+    try tb.setText("AB 测试文字");
+
+    view.setWrapMode(.word);
+    view.setWrapWidth(6);
+
+    // "AB 测" (5) then "试文字" (6); without intercharacter breaks the CJK run
+    // would drop to its own line and force-break after overflowing.
+    try std.testing.expectEqualSlices(u32, &.{ 5, 6 }, view.getCachedLineInfo().line_width_cols);
+}
+
+test "TextBufferView word wrapping - ideographic punctuation never starts a line" {
+    const pool = gp.initGlobalPool(std.testing.allocator);
+    defer gp.deinitGlobalPool();
+    const link_pool = link.initGlobalLinkPool(std.testing.allocator);
+    defer link.deinitGlobalLinkPool();
+
+    var tb = try TextBuffer.init(std.testing.allocator, pool, link_pool, .wcwidth);
+    defer tb.deinit();
+    var view = try TextBufferView.init(std.testing.allocator, tb);
+    defer view.deinit();
+
+    try tb.setText("测试。文字");
+
+    view.setWrapMode(.word);
+    view.setWrapWidth(4);
+
+    // "试。" stays together: no break opportunity exists before 。.
+    try std.testing.expectEqualSlices(u32, &.{ 2, 4, 4 }, view.getCachedLineInfo().line_width_cols);
+}
+
+test "TextBufferView word wrapping - CJK break spans chunk boundary" {
+    const pool = gp.initGlobalPool(std.testing.allocator);
+    defer gp.deinitGlobalPool();
+    const link_pool = link.initGlobalLinkPool(std.testing.allocator);
+    defer link.deinitGlobalLinkPool();
+
+    var tb = try TextBuffer.init(std.testing.allocator, pool, link_pool, .unicode);
+    defer tb.deinit();
+    var view = try TextBufferView.init(std.testing.allocator, tb);
+    defer view.deinit();
+
+    const text = "你好世界";
+    const mem_id = try tb.registerMemBuffer(text, false);
+    var segments: std.ArrayListUnmanaged(seg_mod.Segment) = .empty;
+    defer segments.deinit(std.testing.allocator);
+    try segments.append(std.testing.allocator, .{ .linestart = {} });
+    try segments.append(std.testing.allocator, .{ .text = tb.createChunk(mem_id, 0, 6) });
+    try segments.append(std.testing.allocator, .{ .text = tb.createChunk(mem_id, 6, @intCast(text.len)) });
+    try tb.rope().setSegments(segments.items);
+
+    view.setWrapMode(.word);
+    view.setWrapWidth(4);
+
+    // The 好|世 chunk edge is a break opportunity, so the run fills both lines
+    // instead of carrying "好" into the second chunk as one word.
+    try std.testing.expectEqualSlices(u32, &.{ 4, 4 }, view.getCachedLineInfo().line_width_cols);
 }
 
 test "TextBufferView wrapping - very narrow width (1 char)" {

--- a/packages/native/src/tests/text-buffer-view_test.zig
+++ b/packages/native/src/tests/text-buffer-view_test.zig
@@ -33,6 +33,46 @@ test "TextBufferView first layout retains reusable word metadata" {
     try std.testing.expectEqual(capacity, view.word_layout.arena.queryCapacity());
 }
 
+test "TextBufferView CJK cache survives a failed sibling layout" {
+    const pool = gp.initGlobalPool(std.testing.allocator);
+    defer gp.deinitGlobalPool();
+    const links = link.initGlobalLinkPool(std.testing.allocator);
+    defer link.deinitGlobalLinkPool();
+    const tb = try TextBuffer.init(std.testing.allocator, pool, links, .unicode);
+    defer tb.deinit();
+    try tb.setText("x\n" ++ ("\u{65e5}" ** 512));
+    const healthy = try TextBufferView.init(std.testing.allocator, tb);
+    defer healthy.deinit();
+    healthy.setWrapMode(.word);
+    healthy.setWrapWidth(80);
+    try std.testing.expectEqual(@as(u32, 14), healthy.getVirtualLineCount());
+    const chunk = tb.rope().get(4).?.asText().?;
+    const cached = chunk.getCachedLayoutInfo(tb.tabWidth(), tb.widthMethod()).?;
+    try std.testing.expectEqual(cached.cjk_breaks.ptr, healthy.word_layout.layouts.items[1].cjk_breaks.ptr);
+
+    var failing = std.testing.FailingAllocator.init(std.testing.allocator, .{});
+    const sibling = try TextBufferView.init(failing.allocator(), tb);
+    defer sibling.deinit();
+    sibling.setWrapMode(.word);
+    sibling.setWrapWidth(80);
+    failing.fail_index = failing.alloc_index;
+    try std.testing.expectEqual(@as(u32, 0), sibling.getVirtualLineCount());
+    try std.testing.expect(failing.has_induced_failure);
+    try std.testing.expect(!tb.isViewDirty(healthy.view_id));
+    try std.testing.expect(chunk.getCachedLayoutInfo(tb.tabWidth(), tb.widthMethod()) != null);
+
+    healthy.setWrapWidth(40);
+    try std.testing.expectEqual(@as(u32, 27), healthy.getVirtualLineCount());
+    try std.testing.expectEqual(cached.cjk_breaks.ptr, chunk.getCachedLayoutInfo(tb.tabWidth(), tb.widthMethod()).?.cjk_breaks.ptr);
+
+    failing.fail_index = std.math.maxInt(usize);
+    try std.testing.expectEqual(@as(u32, 14), sibling.getVirtualLineCount());
+    try std.testing.expect(!sibling.virtual_lines_dirty);
+    healthy.setWrapWidth(80);
+    try std.testing.expectEqual(@as(u32, 14), healthy.getVirtualLineCount());
+    try std.testing.expectEqual(cached.cjk_breaks.ptr, chunk.getCachedLayoutInfo(tb.tabWidth(), tb.widthMethod()).?.cjk_breaks.ptr);
+}
+
 test "TextBufferView optional metadata failure preserves every streamed piece" {
     const pool = gp.initGlobalPool(std.testing.allocator);
     defer gp.deinitGlobalPool();
@@ -1541,18 +1581,39 @@ test "TextBufferView word wrapping - CJK break spans chunk boundary" {
     try std.testing.expectEqualSlices(u32, &.{ 4, 4 }, view.getCachedLineInfo().line_width_cols);
 }
 
-test "TextBufferView word wrapping - split graphemes retain byte boundaries" {
+test "TextBufferView word wrapping - non-CJK appends keep chunk-local boundaries" {
     const pool = gp.initGlobalPool(std.testing.allocator);
     defer gp.deinitGlobalPool();
     const link_pool = link.initGlobalLinkPool(std.testing.allocator);
     defer link.deinitGlobalLinkPool();
-    const cases = [_]struct { parts: []const []const u8, width: u32, widths: []const u32, wrapped_bytes: ?[]const u8 = null }{
-        .{ .parts = &.{ "\u{65e5}\u{672c}\u{1f1fa}", "\u{1f1f8}\u{1f1fa}\u{1f1f8}\u{8a9e}\u{6587}" }, .width = 4, .widths = &.{ 2, 4, 4, 2 } },
-        .{ .parts = &.{ "\u{1f1e6}", "\u{0301}", "\u{1f1e7}" }, .width = 1, .widths = &.{ 1, 1 } },
-        .{ .parts = &.{ "\u{672c}\u{1f1e6}", "\u{1f1e7}\u{1f1e8}", "\u{1f1e9}\u{1f1ea}\u{1f1eb}" }, .width = 3, .widths = &.{ 2, 2, 2, 2 } },
-        .{ .parts = &.{ "\u{0301}", " " }, .width = 4, .widths = &.{1} },
-        .{ .parts = &.{"A \u{2060}"}, .width = 1, .widths = &.{ 1, 0 }, .wrapped_bytes = "A\u{2060}" },
+    for ([_]@import("../utf8.zig").WidthMethod{ .unicode, .unicode_wide, .wcwidth, .no_zwj }) |method| {
+        var tb = try TextBuffer.init(std.testing.allocator, pool, link_pool, method);
+        defer tb.deinit();
+        var view = try TextBufferView.init(std.testing.allocator, tb);
+        defer view.deinit();
+        try tb.append("\u{1f1e6}");
+        try tb.append("\u{1f1e7}\u{1f1e8}");
+        try tb.append("\u{1f1e9}\u{1f1ea}\u{1f1eb}");
+        view.setWrapMode(.word);
+        view.setWrapWidth(3);
+        const measured = try view.measureForDimensions(3, 8);
+        try std.testing.expectEqual(@as(u32, 2), measured.line_count);
+        try std.testing.expectEqualSlices(u32, &.{ 3, 3 }, view.getCachedLineInfo().line_width_cols);
+    }
+}
+
+test "TextBufferView word wrapping - CJK policy retains bytes and uses legacy fitting for split chunks" {
+    const pool = gp.initGlobalPool(std.testing.allocator);
+    defer gp.deinitGlobalPool();
+    const link_pool = link.initGlobalLinkPool(std.testing.allocator);
+    defer link.deinitGlobalLinkPool();
+    const cases = [_]struct { parts: []const []const u8, width: u32, widths: []const u32 }{
+        .{ .parts = &.{ "\u{65e5}\u{672c}\u{1f1fa}", "\u{1f1f8}\u{1f1fa}\u{1f1f8}\u{8a9e}\u{6587}" }, .width = 4, .widths = &.{ 4, 4, 4 } },
+        .{ .parts = &.{ "\u{65e5}\u{672c}\u{1f44b}", "\u{1f3fb}\u{8a9e}\u{6587}" }, .width = 4, .widths = &.{ 4, 4, 4 } },
         .{ .parts = &.{ "\u{304b}", "\u{3099}\u{304f}" }, .width = 8, .widths = &.{4} },
+        .{ .parts = &.{ "\u{306f}", "\u{309a}\u{3072}" }, .width = 8, .widths = &.{4} },
+        .{ .parts = &.{"\u{304b}\u{200d}\u{3099}"}, .width = 8, .widths = &.{2} },
+        .{ .parts = &.{"\u{306f}\u{200d}\u{309a}"}, .width = 8, .widths = &.{2} },
         .{ .parts = &.{"AB \u{30ab}\u{30fb}\u{30ca}"}, .width = 6, .widths = &.{ 3, 6 } },
         .{ .parts = &.{ "AB \u{30ab}", "\u{30fb}\u{30ca}" }, .width = 6, .widths = &.{ 3, 6 } },
     };
@@ -1578,7 +1639,7 @@ test "TextBufferView word wrapping - split graphemes retain byte boundaries" {
                     try actual.appendSlice(std.testing.allocator, bytes[chunk.byte_start_in_chunk..][0..chunk.byte_len]);
                 }
             }
-            try std.testing.expectEqualStrings(case.wrapped_bytes orelse expected, actual.items);
+            try std.testing.expectEqualStrings(expected, actual.items);
         }
     }
 }

--- a/packages/native/src/tests/text-buffer-view_test.zig
+++ b/packages/native/src/tests/text-buffer-view_test.zig
@@ -1541,6 +1541,48 @@ test "TextBufferView word wrapping - CJK break spans chunk boundary" {
     try std.testing.expectEqualSlices(u32, &.{ 4, 4 }, view.getCachedLineInfo().line_width_cols);
 }
 
+test "TextBufferView word wrapping - split graphemes retain byte boundaries" {
+    const pool = gp.initGlobalPool(std.testing.allocator);
+    defer gp.deinitGlobalPool();
+    const link_pool = link.initGlobalLinkPool(std.testing.allocator);
+    defer link.deinitGlobalLinkPool();
+    const cases = [_]struct { parts: []const []const u8, width: u32, widths: []const u32, wrapped_bytes: ?[]const u8 = null }{
+        .{ .parts = &.{ "\u{65e5}\u{672c}\u{1f1fa}", "\u{1f1f8}\u{1f1fa}\u{1f1f8}\u{8a9e}\u{6587}" }, .width = 4, .widths = &.{ 2, 4, 4, 2 } },
+        .{ .parts = &.{ "\u{1f1e6}", "\u{0301}", "\u{1f1e7}" }, .width = 1, .widths = &.{ 1, 1 } },
+        .{ .parts = &.{ "\u{672c}\u{1f1e6}", "\u{1f1e7}\u{1f1e8}", "\u{1f1e9}\u{1f1ea}\u{1f1eb}" }, .width = 3, .widths = &.{ 2, 2, 2, 2 } },
+        .{ .parts = &.{ "\u{0301}", " " }, .width = 4, .widths = &.{1} },
+        .{ .parts = &.{"A \u{2060}"}, .width = 1, .widths = &.{ 1, 0 }, .wrapped_bytes = "A\u{2060}" },
+        .{ .parts = &.{ "\u{304b}", "\u{3099}\u{304f}" }, .width = 8, .widths = &.{4} },
+        .{ .parts = &.{"AB \u{30ab}\u{30fb}\u{30ca}"}, .width = 6, .widths = &.{ 3, 6 } },
+        .{ .parts = &.{ "AB \u{30ab}", "\u{30fb}\u{30ca}" }, .width = 6, .widths = &.{ 3, 6 } },
+    };
+    for ([_]@import("../utf8.zig").WidthMethod{ .unicode, .unicode_wide, .wcwidth, .no_zwj }) |method| {
+        for (cases) |case| {
+            var tb = try TextBuffer.init(std.testing.allocator, pool, link_pool, method);
+            defer tb.deinit();
+            var view = try TextBufferView.init(std.testing.allocator, tb);
+            defer view.deinit();
+            for (case.parts) |part| try tb.append(part);
+            view.setWrapMode(.word);
+            view.setWrapWidth(case.width);
+            const measured = try view.measureForDimensions(case.width, 8);
+            try std.testing.expectEqual(case.widths.len, measured.line_count);
+            try std.testing.expectEqualSlices(u32, case.widths, view.getCachedLineInfo().line_width_cols);
+            const expected = try std.mem.concat(std.testing.allocator, u8, case.parts);
+            defer std.testing.allocator.free(expected);
+            var actual: std.ArrayListUnmanaged(u8) = .empty;
+            defer actual.deinit(std.testing.allocator);
+            for (view.getVirtualLines()) |line| {
+                for (line.chunks.items) |chunk| {
+                    const bytes = chunk.chunk.getBytes(tb.memRegistry());
+                    try actual.appendSlice(std.testing.allocator, bytes[chunk.byte_start_in_chunk..][0..chunk.byte_len]);
+                }
+            }
+            try std.testing.expectEqualStrings(case.wrapped_bytes orelse expected, actual.items);
+        }
+    }
+}
+
 test "TextBufferView wrapping - very narrow width (1 char)" {
     const pool = gp.initGlobalPool(std.testing.allocator);
     defer gp.deinitGlobalPool();
@@ -1717,9 +1759,9 @@ test "TextBufferView word wrapping - layout cache OOM falls back to complete str
     try std.testing.expectEqual(@as(u32, 26), measured.line_count);
 
     var failing = std.testing.FailingAllocator.init(std.testing.allocator, .{ .fail_index = 0 });
-    const internal_allocator = tb.allocator;
-    tb.allocator = failing.allocator();
-    defer tb.allocator = internal_allocator;
+    const layout_allocator = tb.layout_cache.allocator;
+    tb.layout_cache.allocator = failing.allocator();
+    defer tb.layout_cache.allocator = layout_allocator;
     const vlines = view.getVirtualLines();
 
     try std.testing.expect(failing.has_induced_failure);

--- a/packages/native/src/tests/text-buffer-view_test.zig
+++ b/packages/native/src/tests/text-buffer-view_test.zig
@@ -33,6 +33,35 @@ test "TextBufferView first layout retains reusable word metadata" {
     try std.testing.expectEqual(capacity, view.word_layout.arena.queryCapacity());
 }
 
+test "TextBufferView fragmented ASCII measurement streams complete words without scratch allocation" {
+    const pool = gp.initGlobalPool(std.testing.allocator);
+    defer gp.deinitGlobalPool();
+    const links = link.initGlobalLinkPool(std.testing.allocator);
+    defer link.deinitGlobalLinkPool();
+    const tb = try TextBuffer.init(std.testing.allocator, pool, links, .unicode);
+    defer tb.deinit();
+    const view = try TextBufferView.init(std.testing.allocator, tb);
+    defer view.deinit();
+    view.setWrapMode(.word);
+    try tb.append("word ");
+    const single = try view.measureForDimensions(10, 24);
+    try std.testing.expectEqual(@as(u32, 1), single.line_count);
+    try std.testing.expectEqual(@as(u32, 5), single.width_cols_max);
+    for (0..63) |_| try tb.append("word ");
+
+    var failing = std.testing.FailingAllocator.init(std.testing.allocator, .{ .fail_index = 0 });
+    view.measure_arena.child_allocator = failing.allocator();
+    for ([_]u32{ 10, 15, 10 }, [_]u32{ 32, 22, 32 }) |width, line_count| {
+        const measured = try view.measureForDimensions(width, 24);
+        try std.testing.expectEqual(line_count, measured.line_count);
+        try std.testing.expectEqual(width, measured.width_cols_max);
+        view.setWrapWidth(width);
+        try std.testing.expectEqual(line_count, view.getVirtualLineCount());
+    }
+    try std.testing.expect(!failing.has_induced_failure);
+    try std.testing.expectEqual(@as(usize, 0), view.measure_arena.queryCapacity());
+}
+
 test "TextBufferView CJK cache survives a failed sibling layout" {
     const pool = gp.initGlobalPool(std.testing.allocator);
     defer gp.deinitGlobalPool();
@@ -1610,6 +1639,7 @@ test "TextBufferView word wrapping - CJK policy retains bytes and uses legacy fi
     const cases = [_]struct { parts: []const []const u8, width: u32, widths: []const u32 }{
         .{ .parts = &.{ "\u{65e5}\u{672c}\u{1f1fa}", "\u{1f1f8}\u{1f1fa}\u{1f1f8}\u{8a9e}\u{6587}" }, .width = 4, .widths = &.{ 4, 4, 4 } },
         .{ .parts = &.{ "\u{65e5}\u{672c}\u{1f44b}", "\u{1f3fb}\u{8a9e}\u{6587}" }, .width = 4, .widths = &.{ 4, 4, 4 } },
+        .{ .parts = &.{ "\u{65e5}\u{672c}\u{1f44b}", "\u{1f3fb}" ++ ("\u{8a9e}\u{6587}" ** 256) ++ "\u{65e5}", "abc" }, .width = 4, .widths = &(([_]u32{4} ** 258) ++ [_]u32{ 2, 3 }) },
         .{ .parts = &.{ "\u{304b}", "\u{3099}\u{304f}" }, .width = 8, .widths = &.{4} },
         .{ .parts = &.{ "\u{306f}", "\u{309a}\u{3072}" }, .width = 8, .widths = &.{4} },
         .{ .parts = &.{"\u{304b}\u{200d}\u{3099}"}, .width = 8, .widths = &.{2} },
@@ -1625,21 +1655,25 @@ test "TextBufferView word wrapping - CJK policy retains bytes and uses legacy fi
             defer view.deinit();
             for (case.parts) |part| try tb.append(part);
             view.setWrapMode(.word);
-            view.setWrapWidth(case.width);
-            const measured = try view.measureForDimensions(case.width, 8);
-            try std.testing.expectEqual(case.widths.len, measured.line_count);
-            try std.testing.expectEqualSlices(u32, case.widths, view.getCachedLineInfo().line_width_cols);
             const expected = try std.mem.concat(std.testing.allocator, u8, case.parts);
             defer std.testing.allocator.free(expected);
             var actual: std.ArrayListUnmanaged(u8) = .empty;
             defer actual.deinit(std.testing.allocator);
-            for (view.getVirtualLines()) |line| {
-                for (line.chunks.items) |chunk| {
-                    const bytes = chunk.chunk.getBytes(tb.memRegistry());
-                    try actual.appendSlice(std.testing.allocator, bytes[chunk.byte_start_in_chunk..][0..chunk.byte_len]);
+            for ([_]u32{ case.width, case.width + 2, case.width }) |width| {
+                view.setWrapWidth(width);
+                const measured = try view.measureForDimensions(width, 8);
+                const lines = view.getCachedLineInfo();
+                try std.testing.expectEqual(lines.line_width_cols.len, measured.line_count);
+                if (width == case.width) try std.testing.expectEqualSlices(u32, case.widths, lines.line_width_cols);
+                actual.clearRetainingCapacity();
+                for (view.getVirtualLines()) |line| {
+                    for (line.chunks.items) |chunk| {
+                        const bytes = chunk.chunk.getBytes(tb.memRegistry());
+                        try actual.appendSlice(std.testing.allocator, bytes[chunk.byte_start_in_chunk..][0..chunk.byte_len]);
+                    }
                 }
+                try std.testing.expectEqualStrings(expected, actual.items);
             }
-            try std.testing.expectEqualStrings(expected, actual.items);
         }
     }
 }

--- a/packages/native/src/tests/text-buffer_test.zig
+++ b/packages/native/src/tests/text-buffer_test.zig
@@ -6,6 +6,123 @@ const iter_mod = @import("../text-buffer-iterators.zig");
 
 const TextBuffer = text_buffer.UnifiedTextBuffer;
 
+test "TextBuffer CJK layout cache does not retain replaced dense metadata" {
+    const pool = gp.initGlobalPool(std.testing.allocator);
+    defer gp.deinitGlobalPool();
+    const link_pool = link.initGlobalLinkPool(std.testing.allocator);
+    defer link.deinitGlobalLinkPool();
+
+    var tracking = std.testing.FailingAllocator.init(std.testing.allocator, .{});
+    const tb = try TextBuffer.init(tracking.allocator(), pool, link_pool, .unicode);
+    defer tb.deinit();
+    const view = try @import("../text-buffer-view.zig").TextBufferView.init(tracking.allocator(), tb);
+    defer view.deinit();
+    view.setWrapMode(.word);
+    view.setWrapWidth(80);
+
+    var text = ("\u{65e5}" ** 4096).*;
+    const mem_id = try tb.registerMemBuffer(&text, false);
+    try tb.setTextFromMemId(mem_id);
+    try std.testing.expectEqual(@as(u32, 103), view.getVirtualLineCount());
+    const initial_bytes = tracking.allocated_bytes - tracking.freed_bytes;
+    for (0..200) |i| {
+        @memcpy(text[text.len - 3 ..], if (i % 2 == 0) "\u{672c}" else "\u{65e5}");
+        try tb.setTextFromMemId(mem_id);
+        try std.testing.expectEqual(@as(u32, 103), view.getVirtualLineCount());
+    }
+    const final_bytes = tracking.allocated_bytes - tracking.freed_bytes;
+    // Persistent rope nodes may grow, but obsolete per-character layouts must not.
+    try std.testing.expect(final_bytes - initial_bytes < 1024 * 1024);
+
+    const original_chunk = tb.rope().get(1).?.asText().?;
+    const cached_ptr = original_chunk.getCachedLayoutInfo(2, .unicode).?.cjk_breaks.ptr;
+    try tb.append("\nx");
+    try std.testing.expect(original_chunk.getCachedLayoutInfo(2, .unicode) != null);
+    try std.testing.expectEqual(@as(u32, 104), view.getVirtualLineCount());
+    try std.testing.expectEqual(cached_ptr, original_chunk.getCachedLayoutInfo(2, .unicode).?.cjk_breaks.ptr);
+
+    try tb.rope().setSegments(&.{ .{ .linestart = {} }, .{ .text = tb.createChunk(mem_id, 0, 6) } });
+    tb.markViewsDirty();
+    const replacement_chunk = tb.rope().get(1).?.asText().?;
+    _ = try tb.getWordLayoutInfoFor(replacement_chunk);
+    try std.testing.expectEqual(@as(u32, 1), view.getVirtualLineCount());
+    try std.testing.expect(replacement_chunk.cold.?.wrap_breaks != null);
+    try std.testing.expect(original_chunk.getCachedLayoutInfo(2, .unicode) == null);
+}
+
+test "TextBuffer CJK layout cache survives history and multiple views" {
+    const pool = gp.initGlobalPool(std.testing.allocator);
+    defer gp.deinitGlobalPool();
+    const link_pool = link.initGlobalLinkPool(std.testing.allocator);
+    defer link.deinitGlobalLinkPool();
+    const tb = try TextBuffer.init(std.testing.allocator, pool, link_pool, .unicode);
+    defer tb.deinit();
+    const TextBufferView = @import("../text-buffer-view.zig").TextBufferView;
+    const first = try TextBufferView.init(std.testing.allocator, tb);
+    defer first.deinit();
+    const second = try TextBufferView.init(std.testing.allocator, tb);
+    defer second.deinit();
+    first.setWrapMode(.word);
+    first.setWrapWidth(80);
+    second.setWrapMode(.word);
+    second.setWrapWidth(100);
+
+    const original = "\u{65e5}" ** 512;
+    const replacement = "\u{672c}" ** 400;
+    try tb.setText(original);
+    try std.testing.expectEqual(@as(u32, 13), first.getVirtualLineCount());
+    const original_chunk = tb.rope().get(1).?.asText().?;
+    const cached_ptr = original_chunk.getCachedLayoutInfo(2, .unicode).?.cjk_breaks.ptr;
+    try std.testing.expectEqual(@as(u32, 11), second.getVirtualLineCount());
+    try std.testing.expectEqual(cached_ptr, original_chunk.getCachedLayoutInfo(2, .unicode).?.cjk_breaks.ptr);
+    tb.setTabWidth(4);
+    try std.testing.expectEqual(cached_ptr, original_chunk.getCachedLayoutInfo(2, .unicode).?.cjk_breaks.ptr);
+    try std.testing.expectEqual(@as(u32, 13), first.getVirtualLineCount());
+    try std.testing.expectEqual(cached_ptr, original_chunk.getCachedLayoutInfo(4, .unicode).?.cjk_breaks.ptr);
+    tb.setTabWidth(2);
+    try tb.rope().store_undo("original");
+
+    try tb.setText(replacement);
+    try std.testing.expect(original_chunk.getCachedLayoutInfo(2, .unicode) == null);
+    try std.testing.expectEqual(@as(u32, 10), first.getVirtualLineCount());
+    try std.testing.expectEqual(@as(u32, 8), second.getVirtualLineCount());
+    try std.testing.expectEqualStrings("original", try tb.undo("replacement"));
+    tb.markViewsDirty();
+    try std.testing.expectEqual(original_chunk, tb.rope().get(1).?.asText().?);
+
+    for ([_]*TextBufferView{ first, second }, [_]u32{ 80, 100 }) |view, width| {
+        var byte_offset: u32 = 0;
+        for (view.getVirtualLines()) |line| {
+            try std.testing.expect(line.width_cols <= width);
+            for (line.chunks.items) |chunk| {
+                try std.testing.expectEqual(byte_offset, chunk.byte_start_in_chunk);
+                const bytes = chunk.chunk.getBytes(tb.memRegistry());
+                try std.testing.expectEqualStrings(original[byte_offset..][0..chunk.byte_len], bytes[chunk.byte_start_in_chunk..][0..chunk.byte_len]);
+                byte_offset += chunk.byte_len;
+            }
+        }
+        try std.testing.expectEqual(original.len, byte_offset);
+    }
+    try std.testing.expectEqualStrings("replacement", try tb.redo());
+    tb.markViewsDirty();
+    try std.testing.expectEqual(@as(u32, 10), first.getVirtualLineCount());
+    try std.testing.expectEqual(@as(u32, 8), second.getVirtualLineCount());
+
+    tb.reset();
+    try std.testing.expectEqual(@as(u32, 1), first.getVirtualLineCount());
+    try tb.setText(original);
+    try std.testing.expectEqual(@as(u32, 11), second.getVirtualLineCount());
+    try tb.setStyledText(&.{.{
+        .text_ptr = replacement.ptr,
+        .text_len = replacement.len,
+        .fg_ptr = null,
+        .bg_ptr = null,
+        .attributes = 0,
+    }});
+    try std.testing.expectEqual(@as(u32, 10), first.getVirtualLineCount());
+    try std.testing.expectEqual(@as(u32, 8), second.getVirtualLineCount());
+}
+
 test "TextBuffer init - creates empty buffer" {
     const pool = gp.initGlobalPool(std.testing.allocator);
     defer gp.deinitGlobalPool();

--- a/packages/native/src/tests/utf8_test.zig
+++ b/packages/native/src/tests/utf8_test.zig
@@ -2,6 +2,42 @@ const std = @import("std");
 const testing = std.testing;
 const utf8 = @import("../utf8.zig");
 
+test "decodeUtf8Unchecked keeps its result in one word" {
+    const decoded = utf8.decodeUtf8Unchecked("\u{65e5}", 0);
+    try testing.expectEqual(@sizeOf(u32), @sizeOf(@TypeOf(decoded)));
+    try testing.expectEqual(@bitSizeOf(u32), @bitSizeOf(@TypeOf(decoded)));
+    try testing.expectEqual(@as(u21, 0x65e5), decoded.cp);
+    try testing.expectEqual(@as(u3, 3), decoded.len);
+    try testing.expectEqual(@as(u8, 0), decoded._padding);
+}
+
+test "decodeUtf8Unchecked preserves scalar values and bounded progress" {
+    var bytes: [5]u8 = undefined;
+    bytes[0] = 'x';
+    for (0..0x110000) |value| {
+        if (value >= 0xD800 and value <= 0xDFFF) continue;
+        const cp: u21 = @intCast(value);
+        const len = try std.unicode.utf8Encode(cp, bytes[1..]);
+        const decoded = utf8.decodeUtf8Unchecked(bytes[0 .. 1 + @as(usize, len)], 1);
+        try testing.expectEqual(cp, decoded.cp);
+        try testing.expectEqual(len, decoded.len);
+    }
+    for ([_][]const u8{ "\u{A2}", "\u{65e5}", "\u{20000}", "\u{10FFFF}" }) |text| {
+        for (1..text.len) |end| {
+            const decoded = utf8.decodeUtf8Unchecked(text[0..end], 0);
+            try testing.expectEqual(@as(u21, 0xFFFD), decoded.cp);
+            try testing.expectEqual(@as(u3, 1), decoded.len);
+        }
+    }
+    for (0..256) |first| {
+        var malformed: [4]u8 = .{ @intCast(first), 0xBF, 0xBF, 0xBF };
+        for (1..5) |len| {
+            const decoded = utf8.decodeUtf8Unchecked(malformed[0..len], 0);
+            try testing.expect(decoded.len > 0 and decoded.len <= len);
+        }
+    }
+}
+
 // ============================================================================
 // ASCII-ONLY DETECTION TESTS
 // ============================================================================

--- a/packages/native/src/tests/utf8_test.zig
+++ b/packages/native/src/tests/utf8_test.zig
@@ -793,6 +793,18 @@ const layout_break_golden_tests = [_]LayoutBreakTestCase{
         .input = "a\u{200B}b",
         .expected = &[_]usize{1},
     },
+    .{
+        .name = "cjk run breaks between characters",
+        .input = "你好世界",
+        .expected = &[_]usize{ 0, 3, 6 },
+    },
+    .{
+        // Breaks after 文 and after 。, but none after 字: the full stop
+        // must not start a line.
+        .name = "no break before ideographic full stop",
+        .input = "文字。",
+        .expected = &[_]usize{ 0, 6 },
+    },
 };
 
 fn testLayoutBreaks(test_case: LayoutBreakTestCase, allocator: std.mem.Allocator) !void {
@@ -892,10 +904,11 @@ test "wrap breaks: multibyte at SIMD boundary with script transitions" {
     const text = "Test世界Test";
     @memcpy(buf[0..text.len], text);
 
-    //// Breaks at ASCII<->CJK transitions:
+    //// Breaks at ASCII<->CJK transitions and between CJK characters:
     // - after 't' in "Test" (byte 3)
+    // - after '世' before '界' (byte 4)
     // - after '界' before "Test" (byte 7)
-    const expected = [_]usize{ 3, 7 };
+    const expected = [_]usize{ 3, 4, 7 };
 
     try testLayoutBreaks(.{
         .name = "unicode@boundary",

--- a/packages/native/src/text-buffer-segment.zig
+++ b/packages/native/src/text-buffer-segment.zig
@@ -27,6 +27,13 @@ pub const WrapMode = enum {
 
 pub const RenderClusterInfo = utf8.RenderClusterInfo;
 pub const ChunkLayoutInfo = utf8.ChunkLayoutInfo;
+pub const WordLayoutInfo = struct {
+    wrap_breaks: []const utf8.LayoutWrapBreak,
+    word_classes: struct {
+        first: utf8.WordClass,
+        last: utf8.WordClass,
+    },
+};
 
 const CachedMeasure = struct {
     wrap_width: u32,
@@ -266,7 +273,7 @@ pub const TextChunk = struct {
         mem_registry: *const MemRegistry,
         tabwidth: u8,
         width_method: utf8.WidthMethod,
-    ) TextBufferError!ChunkLayoutInfo {
+    ) TextBufferError!WordLayoutInfo {
         return self.getLayoutInfoForMode(true, allocator, cache, mem_registry, tabwidth, width_method);
     }
 
@@ -278,7 +285,7 @@ pub const TextChunk = struct {
         mem_registry: *const MemRegistry,
         tabwidth: u8,
         width_method: utf8.WidthMethod,
-    ) TextBufferError!ChunkLayoutInfo {
+    ) TextBufferError!(if (word_only) WordLayoutInfo else ChunkLayoutInfo) {
         const cold = try self.getOrCreateCold(allocator);
         if (cold.wrap_breaks == null) {
             cold.next_layout_cache = cache.first;
@@ -291,9 +298,12 @@ pub const TextChunk = struct {
         if (cold.wrap_breaks_tab_width == tabwidth and cold.wrap_breaks_width_method == width_method and
             (word_only or cold.line_breaks_ready))
         {
-            return .{
+            return if (word_only) .{
                 .wrap_breaks = cached,
-                .cjk_breaks = if (word_only) &.{} else cold.cjk_breaks.items,
+                .word_classes = .{ .first = cold.word_classes.first, .last = cold.word_classes.last },
+            } else .{
+                .wrap_breaks = cached,
+                .cjk_breaks = cold.cjk_breaks.items,
                 .word_classes = cold.word_classes,
             };
         }
@@ -323,9 +333,12 @@ pub const TextChunk = struct {
         cold.line_breaks_ready = !word_only or !word_classes.has_cjk_breaks;
         cold.word_classes = word_classes;
 
-        return .{
+        return if (word_only) .{
             .wrap_breaks = wrap_breaks.items,
-            .cjk_breaks = if (word_only) &.{} else cjk_breaks.items,
+            .word_classes = .{ .first = word_classes.first, .last = word_classes.last },
+        } else .{
+            .wrap_breaks = wrap_breaks.items,
+            .cjk_breaks = cjk_breaks.items,
             .word_classes = word_classes,
         };
     }

--- a/packages/native/src/text-buffer-segment.zig
+++ b/packages/native/src/text-buffer-segment.zig
@@ -27,6 +27,11 @@ pub const WrapMode = enum {
 
 pub const RenderClusterInfo = utf8.RenderClusterInfo;
 pub const ChunkLayoutInfo = utf8.ChunkLayoutInfo;
+pub const WordLayoutInfo = struct {
+    wrap_breaks: []const utf8.LayoutWrapBreak,
+    first_class: utf8.WordClass,
+    last_class: utf8.WordClass,
+};
 
 const CachedMeasure = struct {
     wrap_width: u32,
@@ -46,6 +51,8 @@ pub const TextChunkColdState = struct {
     wrap_breaks_tab_width: ?u8 = null,
     wrap_breaks_width_method: ?utf8.WidthMethod = null,
     word_classes: utf8.WordClassEdges = .{ .first = .other, .last = .other },
+    cjk_breaks: std.ArrayListUnmanaged(utf8.LayoutWrapBreak) = .empty,
+    line_breaks_ready: bool = false,
     measure_word: ?CachedMeasure = null,
 };
 
@@ -110,10 +117,12 @@ pub const TextChunk = struct {
         width_method: utf8.WidthMethod,
     ) ?ChunkLayoutInfo {
         const cold = self.cold orelse return null;
+        if (!cold.line_breaks_ready) return null;
         const cached = cold.wrap_breaks orelse return null;
         if (cold.wrap_breaks_tab_width != tabwidth or cold.wrap_breaks_width_method != width_method) return null;
         return .{
             .wrap_breaks = cached,
+            .cjk_breaks = cold.cjk_breaks.items,
             .word_classes = cold.word_classes,
         };
     }
@@ -208,56 +217,76 @@ pub const TextChunk = struct {
         tabwidth: u8,
         width_method: utf8.WidthMethod,
     ) TextBufferError!ChunkLayoutInfo {
+        return self.getLayoutInfoForMode(false, allocator, mem_registry, tabwidth, width_method);
+    }
+
+    pub fn getWordLayoutInfo(
+        self: *const TextChunk,
+        allocator: Allocator,
+        mem_registry: *const MemRegistry,
+        tabwidth: u8,
+        width_method: utf8.WidthMethod,
+    ) TextBufferError!WordLayoutInfo {
+        return self.getLayoutInfoForMode(true, allocator, mem_registry, tabwidth, width_method);
+    }
+
+    fn getLayoutInfoForMode(
+        self: *const TextChunk,
+        comptime word_only: bool,
+        allocator: Allocator,
+        mem_registry: *const MemRegistry,
+        tabwidth: u8,
+        width_method: utf8.WidthMethod,
+    ) TextBufferError!(if (word_only) WordLayoutInfo else ChunkLayoutInfo) {
         const cold = try self.getOrCreateCold(allocator);
         if (cold.wrap_breaks) |cached| {
-            if (cold.wrap_breaks_tab_width == tabwidth and cold.wrap_breaks_width_method == width_method) {
-                return .{
+            if (cold.wrap_breaks_tab_width == tabwidth and cold.wrap_breaks_width_method == width_method and
+                (word_only or cold.line_breaks_ready))
+            {
+                return if (word_only) .{
                     .wrap_breaks = cached,
+                    .first_class = cold.word_classes.first,
+                    .last_class = cold.word_classes.last,
+                } else .{
+                    .wrap_breaks = cached,
+                    .cjk_breaks = cold.cjk_breaks.items,
                     .word_classes = cold.word_classes,
-                };
-            }
-
-            if (cold.wrap_breaks_width_method == width_method) {
-                var reusable: std.ArrayListUnmanaged(utf8.LayoutWrapBreak) = .{
-                    .items = cached,
-                    .capacity = cold.wrap_breaks_capacity,
-                };
-                reusable.clearRetainingCapacity();
-                const word_classes = try utf8.findChunkLayoutInfo(
-                    allocator,
-                    self.getBytes(mem_registry),
-                    tabwidth,
-                    self.isAsciiOnly(),
-                    width_method,
-                    &reusable,
-                );
-                cold.wrap_breaks = reusable.items;
-                cold.wrap_breaks_capacity = reusable.capacity;
-                cold.wrap_breaks_tab_width = tabwidth;
-                cold.word_classes = word_classes;
-                return .{
-                    .wrap_breaks = reusable.items,
-                    .word_classes = word_classes,
                 };
             }
         }
 
         const chunk_bytes = self.getBytes(mem_registry);
-        var wrap_breaks: std.ArrayListUnmanaged(utf8.LayoutWrapBreak) = .empty;
-        errdefer wrap_breaks.deinit(allocator);
-
-        const word_classes = try utf8.findChunkLayoutInfo(allocator, chunk_bytes, tabwidth, self.isAsciiOnly(), width_method, &wrap_breaks);
-
-        // The static sentinel has zero capacity, so reuse must allocate before writing.
-        const cached: []utf8.LayoutWrapBreak = if (wrap_breaks.items.len > 0) wrap_breaks.items else @constCast(&[_]utf8.LayoutWrapBreak{});
-        cold.wrap_breaks = cached;
-        cold.wrap_breaks_capacity = wrap_breaks.capacity;
-        cold.wrap_breaks_tab_width = tabwidth;
+        var wrap_breaks: std.ArrayListUnmanaged(utf8.LayoutWrapBreak) = if (cold.wrap_breaks_width_method == width_method)
+            .{ .items = cold.wrap_breaks orelse &.{}, .capacity = cold.wrap_breaks_capacity }
+        else
+            .empty;
+        var cjk_breaks = if (cold.wrap_breaks_width_method == width_method) cold.cjk_breaks else std.ArrayListUnmanaged(utf8.LayoutWrapBreak).empty;
+        cjk_breaks.clearRetainingCapacity();
+        // Keep arena-owned storage retryable, but never cache a partial scan on OOM.
+        cold.wrap_breaks_tab_width = null;
         cold.wrap_breaks_width_method = width_method;
+        cold.line_breaks_ready = false;
+        defer {
+            cold.wrap_breaks = wrap_breaks.items;
+            cold.wrap_breaks_capacity = wrap_breaks.capacity;
+            cold.cjk_breaks = cjk_breaks;
+        }
+        // ASCII has no line-only opportunities; both consumers share its scan.
+        const word_classes = if (word_only or self.isAsciiOnly())
+            try utf8.findWordChunkLayoutInfo(allocator, chunk_bytes, tabwidth, self.isAsciiOnly(), width_method, &wrap_breaks)
+        else
+            try utf8.findLineAndWordChunkLayoutInfo(allocator, chunk_bytes, tabwidth, false, width_method, &cjk_breaks, &wrap_breaks);
+        cold.wrap_breaks_tab_width = tabwidth;
+        cold.line_breaks_ready = !word_only or !word_classes.has_cjk_breaks;
         cold.word_classes = word_classes;
 
-        return .{
-            .wrap_breaks = cached,
+        return if (word_only) .{
+            .wrap_breaks = wrap_breaks.items,
+            .first_class = word_classes.first,
+            .last_class = word_classes.last,
+        } else .{
+            .wrap_breaks = wrap_breaks.items,
+            .cjk_breaks = cjk_breaks.items,
             .word_classes = word_classes,
         };
     }

--- a/packages/native/src/text-buffer-segment.zig
+++ b/packages/native/src/text-buffer-segment.zig
@@ -52,8 +52,50 @@ pub const TextChunkColdState = struct {
     wrap_breaks_width_method: ?utf8.WidthMethod = null,
     word_classes: utf8.WordClassEdges = .{ .first = .other, .last = .other },
     cjk_breaks: std.ArrayListUnmanaged(utf8.LayoutWrapBreak) = .empty,
+    next_layout_cache: ?*TextChunkColdState = null,
+    layout_used: bool = false,
     line_breaks_ready: bool = false,
     measure_word: ?CachedMeasure = null,
+};
+
+/// Layout arrays are disposable; the cold states and rope history remain arena-owned.
+/// Each chunk uses one cache, which must be cleared before its arena is reset.
+pub const ChunkLayoutCache = struct {
+    allocator: Allocator,
+    first: ?*TextChunkColdState = null,
+
+    pub fn clear(self: *ChunkLayoutCache) void {
+        self.release(false);
+    }
+
+    pub fn beginLayout(self: *ChunkLayoutCache) void {
+        var entry = self.first;
+        while (entry) |cold| : (entry = cold.next_layout_cache) cold.layout_used = false;
+    }
+
+    pub fn endLayout(self: *ChunkLayoutCache) void {
+        self.release(true);
+    }
+
+    fn release(self: *ChunkLayoutCache, comptime only_unused: bool) void {
+        var entry = &self.first;
+        while (entry.*) |cold| {
+            if (only_unused and cold.layout_used) {
+                entry = &cold.next_layout_cache;
+                continue;
+            }
+            entry.* = cold.next_layout_cache;
+            self.allocator.free(cold.wrap_breaks.?.ptr[0..cold.wrap_breaks_capacity]);
+            cold.cjk_breaks.deinit(self.allocator);
+            cold.wrap_breaks = null;
+            cold.wrap_breaks_capacity = 0;
+            cold.wrap_breaks_tab_width = null;
+            cold.wrap_breaks_width_method = null;
+            cold.cjk_breaks = .empty;
+            cold.next_layout_cache = null;
+            cold.line_breaks_ready = false;
+        }
+    }
 };
 
 pub const WordMeasureSummary = struct {
@@ -117,6 +159,7 @@ pub const TextChunk = struct {
         width_method: utf8.WidthMethod,
     ) ?ChunkLayoutInfo {
         const cold = self.cold orelse return null;
+        cold.layout_used = true;
         if (!cold.line_breaks_ready) return null;
         const cached = cold.wrap_breaks orelse return null;
         if (cold.wrap_breaks_tab_width != tabwidth or cold.wrap_breaks_width_method != width_method) return null;
@@ -209,60 +252,69 @@ pub const TextChunk = struct {
         return render_cluster_list.items;
     }
 
-    /// Lazily compute and cache direct byte/column wrap metadata for this chunk.
+    /// Borrowed layout slices remain valid until cache reclamation or a settings change.
     pub fn getLayoutInfo(
         self: *const TextChunk,
         allocator: Allocator,
+        cache: *ChunkLayoutCache,
         mem_registry: *const MemRegistry,
         tabwidth: u8,
         width_method: utf8.WidthMethod,
     ) TextBufferError!ChunkLayoutInfo {
-        return self.getLayoutInfoForMode(false, allocator, mem_registry, tabwidth, width_method);
+        return self.getLayoutInfoForMode(false, allocator, cache, mem_registry, tabwidth, width_method);
     }
 
     pub fn getWordLayoutInfo(
         self: *const TextChunk,
         allocator: Allocator,
+        cache: *ChunkLayoutCache,
         mem_registry: *const MemRegistry,
         tabwidth: u8,
         width_method: utf8.WidthMethod,
     ) TextBufferError!WordLayoutInfo {
-        return self.getLayoutInfoForMode(true, allocator, mem_registry, tabwidth, width_method);
+        return self.getLayoutInfoForMode(true, allocator, cache, mem_registry, tabwidth, width_method);
     }
 
     fn getLayoutInfoForMode(
         self: *const TextChunk,
         comptime word_only: bool,
         allocator: Allocator,
+        cache: *ChunkLayoutCache,
         mem_registry: *const MemRegistry,
         tabwidth: u8,
         width_method: utf8.WidthMethod,
     ) TextBufferError!(if (word_only) WordLayoutInfo else ChunkLayoutInfo) {
         const cold = try self.getOrCreateCold(allocator);
-        if (cold.wrap_breaks) |cached| {
-            if (cold.wrap_breaks_tab_width == tabwidth and cold.wrap_breaks_width_method == width_method and
-                (word_only or cold.line_breaks_ready))
-            {
-                return if (word_only) .{
-                    .wrap_breaks = cached,
-                    .first_class = cold.word_classes.first,
-                    .last_class = cold.word_classes.last,
-                } else .{
-                    .wrap_breaks = cached,
-                    .cjk_breaks = cold.cjk_breaks.items,
-                    .word_classes = cold.word_classes,
-                };
-            }
+        if (cold.wrap_breaks == null) {
+            cold.next_layout_cache = cache.first;
+            cache.first = cold;
+            // A non-null slice also marks membership, including after a failed scan.
+            cold.wrap_breaks = &.{};
+        }
+        cold.layout_used = true;
+        const cached = cold.wrap_breaks.?;
+        if (cold.wrap_breaks_tab_width == tabwidth and cold.wrap_breaks_width_method == width_method and
+            (word_only or cold.line_breaks_ready))
+        {
+            return if (word_only) .{
+                .wrap_breaks = cached,
+                .first_class = cold.word_classes.first,
+                .last_class = cold.word_classes.last,
+            } else .{
+                .wrap_breaks = cached,
+                .cjk_breaks = cold.cjk_breaks.items,
+                .word_classes = cold.word_classes,
+            };
         }
 
         const chunk_bytes = self.getBytes(mem_registry);
-        var wrap_breaks: std.ArrayListUnmanaged(utf8.LayoutWrapBreak) = if (cold.wrap_breaks_width_method == width_method)
-            .{ .items = cold.wrap_breaks orelse &.{}, .capacity = cold.wrap_breaks_capacity }
-        else
-            .empty;
-        var cjk_breaks = if (cold.wrap_breaks_width_method == width_method) cold.cjk_breaks else std.ArrayListUnmanaged(utf8.LayoutWrapBreak).empty;
+        var wrap_breaks: std.ArrayListUnmanaged(utf8.LayoutWrapBreak) = .{
+            .items = cached,
+            .capacity = cold.wrap_breaks_capacity,
+        };
+        var cjk_breaks = cold.cjk_breaks;
         cjk_breaks.clearRetainingCapacity();
-        // Keep arena-owned storage retryable, but never cache a partial scan on OOM.
+        // Publish owned storage even on OOM so it can be retried or reclaimed.
         cold.wrap_breaks_tab_width = null;
         cold.wrap_breaks_width_method = width_method;
         cold.line_breaks_ready = false;
@@ -273,9 +325,9 @@ pub const TextChunk = struct {
         }
         // ASCII has no line-only opportunities; both consumers share its scan.
         const word_classes = if (word_only or self.isAsciiOnly())
-            try utf8.findWordChunkLayoutInfo(allocator, chunk_bytes, tabwidth, self.isAsciiOnly(), width_method, &wrap_breaks)
+            try utf8.findWordChunkLayoutInfo(cache.allocator, chunk_bytes, tabwidth, self.isAsciiOnly(), width_method, &wrap_breaks)
         else
-            try utf8.findLineAndWordChunkLayoutInfo(allocator, chunk_bytes, tabwidth, false, width_method, &cjk_breaks, &wrap_breaks);
+            try utf8.findLineAndWordChunkLayoutInfo(cache.allocator, chunk_bytes, tabwidth, false, width_method, &cjk_breaks, &wrap_breaks);
         cold.wrap_breaks_tab_width = tabwidth;
         cold.line_breaks_ready = !word_only or !word_classes.has_cjk_breaks;
         cold.word_classes = word_classes;

--- a/packages/native/src/text-buffer-segment.zig
+++ b/packages/native/src/text-buffer-segment.zig
@@ -27,11 +27,6 @@ pub const WrapMode = enum {
 
 pub const RenderClusterInfo = utf8.RenderClusterInfo;
 pub const ChunkLayoutInfo = utf8.ChunkLayoutInfo;
-pub const WordLayoutInfo = struct {
-    wrap_breaks: []const utf8.LayoutWrapBreak,
-    first_class: utf8.WordClass,
-    last_class: utf8.WordClass,
-};
 
 const CachedMeasure = struct {
     wrap_width: u32,
@@ -271,7 +266,7 @@ pub const TextChunk = struct {
         mem_registry: *const MemRegistry,
         tabwidth: u8,
         width_method: utf8.WidthMethod,
-    ) TextBufferError!WordLayoutInfo {
+    ) TextBufferError!ChunkLayoutInfo {
         return self.getLayoutInfoForMode(true, allocator, cache, mem_registry, tabwidth, width_method);
     }
 
@@ -283,7 +278,7 @@ pub const TextChunk = struct {
         mem_registry: *const MemRegistry,
         tabwidth: u8,
         width_method: utf8.WidthMethod,
-    ) TextBufferError!(if (word_only) WordLayoutInfo else ChunkLayoutInfo) {
+    ) TextBufferError!ChunkLayoutInfo {
         const cold = try self.getOrCreateCold(allocator);
         if (cold.wrap_breaks == null) {
             cold.next_layout_cache = cache.first;
@@ -296,13 +291,9 @@ pub const TextChunk = struct {
         if (cold.wrap_breaks_tab_width == tabwidth and cold.wrap_breaks_width_method == width_method and
             (word_only or cold.line_breaks_ready))
         {
-            return if (word_only) .{
+            return .{
                 .wrap_breaks = cached,
-                .first_class = cold.word_classes.first,
-                .last_class = cold.word_classes.last,
-            } else .{
-                .wrap_breaks = cached,
-                .cjk_breaks = cold.cjk_breaks.items,
+                .cjk_breaks = if (word_only) &.{} else cold.cjk_breaks.items,
                 .word_classes = cold.word_classes,
             };
         }
@@ -332,13 +323,9 @@ pub const TextChunk = struct {
         cold.line_breaks_ready = !word_only or !word_classes.has_cjk_breaks;
         cold.word_classes = word_classes;
 
-        return if (word_only) .{
+        return .{
             .wrap_breaks = wrap_breaks.items,
-            .first_class = word_classes.first,
-            .last_class = word_classes.last,
-        } else .{
-            .wrap_breaks = wrap_breaks.items,
-            .cjk_breaks = cjk_breaks.items,
+            .cjk_breaks = if (word_only) &.{} else cjk_breaks.items,
             .word_classes = word_classes,
         };
     }

--- a/packages/native/src/text-buffer-view.zig
+++ b/packages/native/src/text-buffer-view.zig
@@ -156,6 +156,11 @@ const PendingWordPieceFit = struct {
     bytes_used: u32,
 };
 
+const PendingWordPrefixFit = struct {
+    full_pieces: usize,
+    last_piece: PendingWordPieceFit,
+};
+
 pub const VirtualLine = struct {
     chunks: std.ArrayListUnmanaged(VirtualChunk),
     width_cols: u32,
@@ -1576,12 +1581,14 @@ pub const UnifiedTextBufferView = struct {
             line_idx: u32 = 0,
             source_line_col_offset: u32 = 0,
             current_vline_width_cols: u32 = 0,
+            measure_has_content: if (calculation == .measure) bool else void = if (calculation == .measure) false else {},
             current_vline: if (calculation == .render) VirtualLine else void = if (calculation == .render) VirtualLine.init() else {},
             current_line_first_vline_idx: if (calculation == .render) u32 else void = if (calculation == .render) 0 else {},
             current_line_vline_count: if (calculation == .render) u32 else void = if (calculation == .render) 0 else {},
             pending_word_pieces: if (wrap_mode == .word) std.ArrayListUnmanaged(PendingWordPiece) else void = if (wrap_mode == .word) .empty else {},
             pending_word_width_cols: if (wrap_mode == .word) u32 else void = if (wrap_mode == .word) 0 else {},
-            pending_word_has_split_grapheme: if (wrap_mode == .word) bool else void = if (wrap_mode == .word) false else {},
+            // Index of the last piece joined to its predecessor; zero means no remaining split.
+            pending_word_last_split: if (wrap_mode == .word) usize else void = if (wrap_mode == .word) 0 else {},
             pending_word_edges: if (wrap_mode == .word) utf8.WordClassEdges else void = if (wrap_mode == .word) .{ .first = .other, .last = .other } else {},
             source_line_has_non_whitespace: if (wrap_mode == .word) bool else void = if (wrap_mode == .word) false else {},
             word_chunk: if (wrap_mode == .word) ?*const TextChunk else void = if (wrap_mode == .word) null else {},
@@ -1616,6 +1623,7 @@ pub const UnifiedTextBufferView = struct {
                     wctx.current_vline.document_cell_offset = wctx.document_cell_offset;
                 }
                 wctx.current_vline_width_cols = 0;
+                if (comptime calculation == .measure) wctx.measure_has_content = false;
                 wctx.current_wrap_width = wctx.wrap_w;
             }
 
@@ -1639,6 +1647,7 @@ pub const UnifiedTextBufferView = struct {
 
             inline fn addVirtualChunk(wctx: *@This(), chunk: *const TextChunk, byte_start: u32, byte_len: u32, col_start: u32, width_cols: u32) Allocator.Error!void {
                 if (byte_len == 0) return;
+                if (comptime calculation == .measure) wctx.measure_has_content = true;
 
                 if (comptime calculation == .render and wrap_mode == .word) {
                     if (wctx.current_vline.chunks.items.len > 0) {
@@ -1694,7 +1703,7 @@ pub const UnifiedTextBufferView = struct {
             }
 
             fn queuePendingWordPiece(wctx: *@This(), chunk: *const TextChunk, col_start_in_chunk: u32, width_cols: u32, byte_start: u32, byte_end: u32) void {
-                if (width_cols == 0 or wctx.failed) return;
+                if (byte_start == byte_end or wctx.failed) return;
 
                 if (wctx.pending_word_pieces.items.len > 0) {
                     const last = &wctx.pending_word_pieces.items[wctx.pending_word_pieces.items.len - 1];
@@ -1722,7 +1731,7 @@ pub const UnifiedTextBufferView = struct {
             fn clearPendingWord(wctx: *@This()) void {
                 wctx.pending_word_pieces.clearRetainingCapacity();
                 wctx.pending_word_width_cols = 0;
-                wctx.pending_word_has_split_grapheme = false;
+                wctx.pending_word_last_split = 0;
                 wctx.pending_word_edges = .{ .first = .other, .last = .other };
             }
 
@@ -1737,6 +1746,7 @@ pub const UnifiedTextBufferView = struct {
                     );
                 }
                 wctx.pending_word_pieces.items.len = remaining;
+                wctx.pending_word_last_split -|= count;
             }
 
             fn fitPendingWordPiece(wctx: *@This(), piece: PendingWordPiece, max_width_cols: u32, allow_forced_grapheme: bool) PendingWordPieceFit {
@@ -1786,17 +1796,19 @@ pub const UnifiedTextBufferView = struct {
                 };
             }
 
-            fn fitPendingWordWidth(wctx: *@This(), max_width_cols: u32) u32 {
+            fn fitPendingWordPrefix(wctx: *@This(), max_width_cols: u32) PendingWordPrefixFit {
                 // A public append may split a grapheme across chunks. Keep its
-                // parts together, but retain the chunks' source-column units.
+                // exact byte boundary while retaining the chunks' source-column units.
                 var break_state: @import("uucode").grapheme.BreakState = .default;
                 var prev_cp: ?u21 = null;
                 var cols: u32 = 0;
                 var fit_cols: u32 = 0;
+                var fit: PendingWordPrefixFit = .{ .full_pieces = 0, .last_piece = .{ .width_cols = 0, .bytes_used = 0 } };
                 const width_method = wctx.text_buffer.widthMethod();
-                for (wctx.pending_word_pieces.items) |piece| {
+                for (wctx.pending_word_pieces.items, 0..) |piece, piece_idx| {
                     const bytes = piece.chunk.getBytes(wctx.text_buffer.memRegistry());
                     var pos: usize = piece.byte_start;
+                    const cols_before_piece = cols;
                     var width_state: utf8.GraphemeWidthState = undefined;
                     var local_state: @import("uucode").grapheme.BreakState = .default;
                     var local_prev_cp: ?u21 = null;
@@ -1804,8 +1816,13 @@ pub const UnifiedTextBufferView = struct {
                         const decoded = utf8.decodeUtf8Unchecked(bytes, pos);
                         const is_break = utf8.isGraphemeBreak(prev_cp, decoded.cp, &break_state, width_method);
                         if (is_break) {
-                            if (cols > max_width_cols) return if (fit_cols > 0) fit_cols else cols;
+                            const boundary: PendingWordPrefixFit = .{
+                                .full_pieces = piece_idx,
+                                .last_piece = .{ .width_cols = cols - cols_before_piece, .bytes_used = @intCast(pos - piece.byte_start) },
+                            };
+                            if (cols > max_width_cols) return if (fit_cols > 0) fit else boundary;
                             fit_cols = cols;
+                            fit = boundary;
                         }
                         const width = utf8.charWidth(bytes[pos], decoded.cp, wctx.text_buffer.tabWidth());
                         if (utf8.isGraphemeBreak(local_prev_cp, decoded.cp, &local_state, width_method)) {
@@ -1821,41 +1838,46 @@ pub const UnifiedTextBufferView = struct {
                         pos += decoded.len;
                     }
                 }
-                return if (cols <= max_width_cols or fit_cols == 0) cols else fit_cols;
+                return if (cols <= max_width_cols or fit_cols == 0)
+                    .{ .full_pieces = wctx.pending_word_pieces.items.len, .last_piece = .{ .width_cols = 0, .bytes_used = 0 } }
+                else
+                    fit;
             }
 
             fn consumePendingWordPrefix(wctx: *@This(), max_width_cols: u32) bool {
                 if (max_width_cols == 0 or wctx.pending_word_width_cols == 0 or wctx.failed) return false;
 
                 const vline_width_cols_before = wctx.current_vline_width_cols;
-                var remaining_width_cols = if (wctx.pending_word_has_split_grapheme)
-                    fitPendingWordWidth(wctx, max_width_cols)
+                const prefix_fit: ?PendingWordPrefixFit = if (wctx.pending_word_last_split > 0)
+                    fitPendingWordPrefix(wctx, max_width_cols)
                 else
-                    max_width_cols;
+                    null;
+                var remaining_width_cols = max_width_cols;
                 var consumed_count: usize = 0;
-                while (consumed_count < wctx.pending_word_pieces.items.len and remaining_width_cols > 0) {
+                while (consumed_count < wctx.pending_word_pieces.items.len) {
                     const piece = wctx.pending_word_pieces.items[consumed_count];
-                    if (piece.width_cols <= remaining_width_cols) {
-                        if (!addVirtualChunkSticky(wctx, piece.chunk, piece.byte_start, piece.byte_end - piece.byte_start, piece.col_start_in_chunk, piece.width_cols)) return false;
-                        remaining_width_cols -= piece.width_cols;
+                    const fit = if (prefix_fit) |prefix| blk: {
+                        if (consumed_count < prefix.full_pieces) break :blk PendingWordPieceFit{ .width_cols = piece.width_cols, .bytes_used = piece.byte_end - piece.byte_start };
+                        break :blk prefix.last_piece;
+                    } else fitPendingWordPiece(wctx, piece, remaining_width_cols, wctx.current_vline_width_cols == vline_width_cols_before);
+                    if (fit.bytes_used == 0) break;
+                    if (!addVirtualChunkSticky(wctx, piece.chunk, piece.byte_start, fit.bytes_used, piece.col_start_in_chunk, fit.width_cols)) return false;
+                    remaining_width_cols -|= fit.width_cols;
+                    if (fit.bytes_used == piece.byte_end - piece.byte_start) {
                         consumed_count += 1;
                         continue;
                     }
 
-                    const fit = fitPendingWordPiece(wctx, piece, remaining_width_cols, wctx.current_vline_width_cols == vline_width_cols_before);
-                    if (fit.width_cols == 0) break;
-                    if (!addVirtualChunkSticky(wctx, piece.chunk, piece.byte_start, fit.bytes_used, piece.col_start_in_chunk, fit.width_cols)) return false;
                     wctx.pending_word_pieces.items[consumed_count].col_start_in_chunk += fit.width_cols;
                     wctx.pending_word_pieces.items[consumed_count].width_cols -= fit.width_cols;
                     wctx.pending_word_pieces.items[consumed_count].byte_start += fit.bytes_used;
-                    if (wctx.pending_word_pieces.items[consumed_count].width_cols == 0) consumed_count += 1;
                     break;
                 }
 
                 dropPendingWordPrefix(wctx, consumed_count);
                 const consumed_width_cols = wctx.current_vline_width_cols - vline_width_cols_before;
                 wctx.pending_word_width_cols -= consumed_width_cols;
-                if (wctx.pending_word_width_cols == 0) clearPendingWord(wctx);
+                if (wctx.pending_word_pieces.items.len == 0) clearPendingWord(wctx);
                 return consumed_width_cols > 0;
             }
 
@@ -1867,7 +1889,7 @@ pub const UnifiedTextBufferView = struct {
             }
 
             fn finalizePendingWord(wctx: *@This()) void {
-                while (wctx.pending_word_width_cols > 0 and !wctx.failed) {
+                while (wctx.pending_word_pieces.items.len > 0 and !wctx.failed) {
                     const wrap_limit_cols = wctx.wordWrapWidth();
                     if (wctx.current_vline_width_cols > 0 and wctx.current_vline_width_cols + wctx.pending_word_width_cols > wrap_limit_cols) {
                         if (!commitVirtualLineSticky(wctx)) return;
@@ -1913,7 +1935,7 @@ pub const UnifiedTextBufferView = struct {
 
             fn flushCompleteWordPiece(wctx: *@This(), chunk: *const TextChunk, col_start_in_chunk: u32, width_cols: u32, byte_start: u32, byte_end: u32) void {
                 if (width_cols == 0 or wctx.failed) return;
-                if (wctx.pending_word_width_cols > 0) {
+                if (wctx.pending_word_pieces.items.len > 0) {
                     queuePendingWordPiece(wctx, chunk, col_start_in_chunk, width_cols, byte_start, byte_end);
                     finalizePendingWord(wctx);
                 } else {
@@ -1941,7 +1963,7 @@ pub const UnifiedTextBufferView = struct {
                     );
                     if (wctx.failed) return;
                     wctx.source_line_has_non_whitespace = true;
-                } else if (wctx.pending_word_width_cols > 0) {
+                } else if (wctx.pending_word_pieces.items.len > 0) {
                     finalizePendingWord(wctx);
                     if (wctx.failed) return;
                 }
@@ -2056,18 +2078,34 @@ pub const UnifiedTextBufferView = struct {
                     info.word_classes
                 else
                     utf8.chunkWordClassEdges(chunk_bytes);
-                if (wctx.pending_word_width_cols > 0 and chunk_bytes.len > 0) {
+                var continued_state: ?@import("uucode").grapheme.BreakState = null;
+                if (wctx.pending_word_pieces.items.len > 0 and chunk_bytes.len > 0) {
                     var state = wctx.pending_word_edges.break_state;
+                    const first = utf8.decodeUtf8Unchecked(chunk_bytes, 0);
+                    const first_cp = first.cp;
                     const is_break = (chunk.isAsciiOnly() and (wctx.pending_word_edges.last_cp orelse 0) < 0x80) or
-                        utf8.isGraphemeBreak(wctx.pending_word_edges.last_cp, utf8.decodeUtf8Unchecked(chunk_bytes, 0).cp, &state, wctx.text_buffer.widthMethod());
+                        utf8.isGraphemeBreak(wctx.pending_word_edges.last_cp, first_cp, &state, wctx.text_buffer.widthMethod());
                     if (!is_break) {
-                        wctx.pending_word_has_split_grapheme = true;
+                        wctx.pending_word_last_split = wctx.pending_word_pieces.items.len;
                     } else if (utf8.isCjkAsciiTransition(wctx.pending_word_edges.last, word_classes.first) or
-                        utf8.isCjkIntercharacterBreak(wctx.pending_word_edges.last, word_classes.first))
+                        utf8.isCjkIntercharacterBreak(wctx.pending_word_edges.last, word_classes.first, first_cp))
                     {
                         finalizePendingWord(wctx);
                         if (wctx.failed) return;
                     }
+                    // Carry context through a leading RI/ZWJ run until it agrees
+                    // with the chunk-local scan. The rest needs no second scan.
+                    var local_state: @import("uucode").grapheme.BreakState = .default;
+                    var prev_cp = first_cp;
+                    var pos: usize = first.len;
+                    while (state != local_state and pos < chunk_bytes.len) {
+                        const decoded = utf8.decodeUtf8Unchecked(chunk_bytes, pos);
+                        _ = utf8.isGraphemeBreak(prev_cp, decoded.cp, &state, wctx.text_buffer.widthMethod());
+                        _ = utf8.isGraphemeBreak(prev_cp, decoded.cp, &local_state, wctx.text_buffer.widthMethod());
+                        prev_cp = decoded.cp;
+                        pos += decoded.len;
+                    }
+                    if (state != local_state) continued_state = state;
                 }
                 wctx.word_chunk = chunk;
                 wctx.word_chunk_col_start = 0;
@@ -2110,7 +2148,7 @@ pub const UnifiedTextBufferView = struct {
                     break :blk streamed_layout;
                 };
 
-                if (wctx.word_chunk_col_start < chunk.width_cols) {
+                if (wctx.word_chunk_byte_start < chunk_bytes.len) {
                     queuePendingWordPiece(
                         wctx,
                         chunk,
@@ -2119,8 +2157,11 @@ pub const UnifiedTextBufferView = struct {
                         wctx.word_chunk_byte_start,
                         @intCast(chunk_bytes.len),
                     );
-                    if (!wctx.failed) wctx.pending_word_edges = edges;
-                    wctx.source_line_has_non_whitespace = true;
+                    if (!wctx.failed) {
+                        wctx.pending_word_edges = edges;
+                        if (continued_state) |state| wctx.pending_word_edges.break_state = state;
+                    }
+                    if (wctx.word_chunk_col_start < chunk.width_cols) wctx.source_line_has_non_whitespace = true;
                 }
                 wctx.word_chunk = null;
             }
@@ -2258,7 +2299,7 @@ pub const UnifiedTextBufferView = struct {
                 const has_content = if (comptime calculation == .render)
                     wctx.current_vline.chunks.items.len > 0
                 else
-                    wctx.current_vline_width_cols > 0;
+                    wctx.measure_has_content;
                 if (!used_measure_cache and (has_content or line_info.width_cols == 0)) {
                     if (comptime calculation == .render) {
                         wctx.current_vline.width_cols = wctx.current_vline_width_cols;
@@ -2314,6 +2355,7 @@ pub const UnifiedTextBufferView = struct {
                 wctx.line_idx += 1;
                 wctx.source_line_col_offset = 0;
                 wctx.current_vline_width_cols = 0;
+                if (comptime calculation == .measure) wctx.measure_has_content = false;
                 wctx.current_wrap_width = wctx.wrap_w;
                 if (comptime calculation == .render) {
                     wctx.current_vline = VirtualLine.init();
@@ -2343,7 +2385,11 @@ pub const UnifiedTextBufferView = struct {
                 wrap_w,
         };
 
+        // Preserve unchanged chunks across edits; discard detached/history layouts
+        // only after the current rope has marked the caches it still uses.
+        if (comptime calculation == .render and wrap_mode == .word) text_buffer.layout_cache.beginLayout();
         text_buffer.walkLinesAndSegments(&wrap_ctx, WrapContext.segment_callback, WrapContext.line_end_callback);
+        if (comptime calculation == .render and wrap_mode == .word) text_buffer.layout_cache.endLayout();
         return !wrap_ctx.failed;
     }
 };

--- a/packages/native/src/text-buffer-view.zig
+++ b/packages/native/src/text-buffer-view.zig
@@ -1582,6 +1582,7 @@ pub const UnifiedTextBufferView = struct {
             pending_word_pieces: if (wrap_mode == .word) std.ArrayListUnmanaged(PendingWordPiece) else void = if (wrap_mode == .word) .empty else {},
             pending_word_width_cols: if (wrap_mode == .word) u32 else void = if (wrap_mode == .word) 0 else {},
             pending_word_last_class: if (wrap_mode == .word) utf8.WordClass else void = if (wrap_mode == .word) .other else {},
+            word_line_preflight: if (wrap_mode == .word) bool else void,
             word_line_chunks: if (wrap_mode == .word) std.ArrayListUnmanaged(*const TextChunk) else void = if (wrap_mode == .word) .empty else {},
             word_line_first_chunk: if (wrap_mode == .word) ?*const TextChunk else void = if (wrap_mode == .word) null else {},
             word_line_last_cp: if (wrap_mode == .word) ?u21 else void = if (wrap_mode == .word) null else {},
@@ -1977,10 +1978,12 @@ pub const UnifiedTextBufferView = struct {
                 else blk: {
                     if (comptime calculation == .render) {
                         if (!chunk.isAsciiOnly() and chunk_bytes.len >= 1024 and chunk_bytes.len <= 64 * 1024) {
-                            const info = if (wctx.source_line_cjk_breaks)
+                            const info: seg_mod.TextBufferError!utf8.ChunkLayoutInfo = if (wctx.source_line_cjk_breaks)
                                 wctx.text_buffer.getLayoutInfoFor(chunk)
-                            else
-                                wctx.text_buffer.getWordLayoutInfoFor(chunk);
+                            else if (wctx.text_buffer.getWordLayoutInfoFor(chunk)) |word_info| .{
+                                .wrap_breaks = word_info.wrap_breaks,
+                                .word_classes = .{ .first = word_info.word_classes.first, .last = word_info.word_classes.last },
+                            } else |err| err;
                             break :blk info catch |err| switch (err) {
                                 error.OutOfMemory => null,
                                 else => {
@@ -2147,11 +2150,27 @@ pub const UnifiedTextBufferView = struct {
                 }
             }
 
-            fn segment_callback(ctx_ptr: *anyopaque, _: u32, chunk: *const TextChunk, _: u32) void {
+            fn segment_callback(ctx_ptr: *anyopaque, _: u32, chunk: *const TextChunk, chunk_idx_in_line: u32) void {
                 const wctx = @as(*@This(), @ptrCast(@alignCast(ctx_ptr)));
                 if (wctx.failed) return;
 
                 if (comptime wrap_mode == .word) {
+                    // Printable ASCII cannot join graphemes across chunks. Stream it,
+                    // retaining the single-chunk measurement-summary shortcut.
+                    if (!wctx.word_line_preflight) {
+                        if (comptime calculation == .measure) {
+                            if (wctx.word_line_first_chunk) |first| {
+                                processWordChunk(wctx, first);
+                                wctx.word_line_first_chunk = null;
+                                if (wctx.failed) return;
+                            } else if (chunk_idx_in_line == 0) {
+                                wctx.word_line_first_chunk = chunk;
+                                return;
+                            }
+                        }
+                        processWordChunk(wctx, chunk);
+                        return;
+                    }
                     // Decide the policy before emitting any CJK opportunities. Retain
                     // only this line's chunk pointers, without rescanning its bytes.
                     if (wctx.word_line_first_chunk == null) {
@@ -2320,6 +2339,7 @@ pub const UnifiedTextBufferView = struct {
             .allocator = allocator,
             .result = result,
             .word_layout = word_layout,
+            .word_line_preflight = if (comptime wrap_mode == .word) !text_buffer.rope().root.metrics().custom.ascii_only else {},
             .wrap_w = wrap_w,
             .current_wrap_width = if (first_line_offset > 0 and first_line_offset < wrap_w)
                 wrap_w - first_line_offset

--- a/packages/native/src/text-buffer-view.zig
+++ b/packages/native/src/text-buffer-view.zig
@@ -1581,7 +1581,8 @@ pub const UnifiedTextBufferView = struct {
             current_line_vline_count: if (calculation == .render) u32 else void = if (calculation == .render) 0 else {},
             pending_word_pieces: if (wrap_mode == .word) std.ArrayListUnmanaged(PendingWordPiece) else void = if (wrap_mode == .word) .empty else {},
             pending_word_width_cols: if (wrap_mode == .word) u32 else void = if (wrap_mode == .word) 0 else {},
-            pending_word_last_class: if (wrap_mode == .word) utf8.WordClass else void = if (wrap_mode == .word) .other else {},
+            pending_word_has_split_grapheme: if (wrap_mode == .word) bool else void = if (wrap_mode == .word) false else {},
+            pending_word_edges: if (wrap_mode == .word) utf8.WordClassEdges else void = if (wrap_mode == .word) .{ .first = .other, .last = .other } else {},
             source_line_has_non_whitespace: if (wrap_mode == .word) bool else void = if (wrap_mode == .word) false else {},
             word_chunk: if (wrap_mode == .word) ?*const TextChunk else void = if (wrap_mode == .word) null else {},
             word_chunk_col_start: if (wrap_mode == .word) u32 else void = if (wrap_mode == .word) 0 else {},
@@ -1721,7 +1722,8 @@ pub const UnifiedTextBufferView = struct {
             fn clearPendingWord(wctx: *@This()) void {
                 wctx.pending_word_pieces.clearRetainingCapacity();
                 wctx.pending_word_width_cols = 0;
-                wctx.pending_word_last_class = .other;
+                wctx.pending_word_has_split_grapheme = false;
+                wctx.pending_word_edges = .{ .first = .other, .last = .other };
             }
 
             fn dropPendingWordPrefix(wctx: *@This(), count: usize) void {
@@ -1784,11 +1786,52 @@ pub const UnifiedTextBufferView = struct {
                 };
             }
 
+            fn fitPendingWordWidth(wctx: *@This(), max_width_cols: u32) u32 {
+                // A public append may split a grapheme across chunks. Keep its
+                // parts together, but retain the chunks' source-column units.
+                var break_state: @import("uucode").grapheme.BreakState = .default;
+                var prev_cp: ?u21 = null;
+                var cols: u32 = 0;
+                var fit_cols: u32 = 0;
+                const width_method = wctx.text_buffer.widthMethod();
+                for (wctx.pending_word_pieces.items) |piece| {
+                    const bytes = piece.chunk.getBytes(wctx.text_buffer.memRegistry());
+                    var pos: usize = piece.byte_start;
+                    var width_state: utf8.GraphemeWidthState = undefined;
+                    var local_state: @import("uucode").grapheme.BreakState = .default;
+                    var local_prev_cp: ?u21 = null;
+                    while (pos < piece.byte_end) {
+                        const decoded = utf8.decodeUtf8Unchecked(bytes, pos);
+                        const is_break = utf8.isGraphemeBreak(prev_cp, decoded.cp, &break_state, width_method);
+                        if (is_break) {
+                            if (cols > max_width_cols) return if (fit_cols > 0) fit_cols else cols;
+                            fit_cols = cols;
+                        }
+                        const width = utf8.charWidth(bytes[pos], decoded.cp, wctx.text_buffer.tabWidth());
+                        if (utf8.isGraphemeBreak(local_prev_cp, decoded.cp, &local_state, width_method)) {
+                            width_state = .init(decoded.cp, width, width_method);
+                            cols += width_state.width;
+                        } else {
+                            const before = width_state.width;
+                            width_state.addCodepoint(decoded.cp, width);
+                            cols += width_state.width - before;
+                        }
+                        prev_cp = decoded.cp;
+                        local_prev_cp = decoded.cp;
+                        pos += decoded.len;
+                    }
+                }
+                return if (cols <= max_width_cols or fit_cols == 0) cols else fit_cols;
+            }
+
             fn consumePendingWordPrefix(wctx: *@This(), max_width_cols: u32) bool {
                 if (max_width_cols == 0 or wctx.pending_word_width_cols == 0 or wctx.failed) return false;
 
                 const vline_width_cols_before = wctx.current_vline_width_cols;
-                var remaining_width_cols = max_width_cols;
+                var remaining_width_cols = if (wctx.pending_word_has_split_grapheme)
+                    fitPendingWordWidth(wctx, max_width_cols)
+                else
+                    max_width_cols;
                 var consumed_count: usize = 0;
                 while (consumed_count < wctx.pending_word_pieces.items.len and remaining_width_cols > 0) {
                     const piece = wctx.pending_word_pieces.items[consumed_count];
@@ -1812,6 +1855,7 @@ pub const UnifiedTextBufferView = struct {
                 dropPendingWordPrefix(wctx, consumed_count);
                 const consumed_width_cols = wctx.current_vline_width_cols - vline_width_cols_before;
                 wctx.pending_word_width_cols -= consumed_width_cols;
+                if (wctx.pending_word_width_cols == 0) clearPendingWord(wctx);
                 return consumed_width_cols > 0;
             }
 
@@ -2012,22 +2056,45 @@ pub const UnifiedTextBufferView = struct {
                     info.word_classes
                 else
                     utf8.chunkWordClassEdges(chunk_bytes);
-                if (wctx.pending_word_width_cols > 0 and
-                    (utf8.isCjkAsciiTransition(wctx.pending_word_last_class, word_classes.first) or
-                        utf8.isCjkIntercharacterBreak(wctx.pending_word_last_class, word_classes.first)))
-                {
-                    finalizePendingWord(wctx);
-                    if (wctx.failed) return;
+                if (wctx.pending_word_width_cols > 0 and chunk_bytes.len > 0) {
+                    var state = wctx.pending_word_edges.break_state;
+                    const is_break = (chunk.isAsciiOnly() and (wctx.pending_word_edges.last_cp orelse 0) < 0x80) or
+                        utf8.isGraphemeBreak(wctx.pending_word_edges.last_cp, utf8.decodeUtf8Unchecked(chunk_bytes, 0).cp, &state, wctx.text_buffer.widthMethod());
+                    if (!is_break) {
+                        wctx.pending_word_has_split_grapheme = true;
+                    } else if (utf8.isCjkAsciiTransition(wctx.pending_word_edges.last, word_classes.first) or
+                        utf8.isCjkIntercharacterBreak(wctx.pending_word_edges.last, word_classes.first))
+                    {
+                        finalizePendingWord(wctx);
+                        if (wctx.failed) return;
+                    }
                 }
                 wctx.word_chunk = chunk;
                 wctx.word_chunk_col_start = 0;
                 wctx.word_chunk_byte_start = 0;
-                const last_word_class = if (layout) |info| blk: {
-                    for (info.wrap_breaks) |wrap_break| {
-                        processWordWrapBreakValue(wctx, wrap_break);
-                        if (wctx.failed) return;
+                const edges = if (layout) |info| blk: {
+                    if (info.wrap_breaks.len == 0 or info.cjk_breaks.len == 0) {
+                        const breaks = if (info.wrap_breaks.len == 0) info.cjk_breaks else info.wrap_breaks;
+                        for (breaks) |wrap_break| {
+                            processWordWrapBreakValue(wctx, wrap_break);
+                            if (wctx.failed) return;
+                        }
+                    } else {
+                        var word_idx: usize = 0;
+                        for (info.cjk_breaks) |line_break| {
+                            while (word_idx < info.wrap_breaks.len and info.wrap_breaks[word_idx].byte_start < line_break.byte_start) : (word_idx += 1) {
+                                processWordWrapBreakValue(wctx, info.wrap_breaks[word_idx]);
+                                if (wctx.failed) return;
+                            }
+                            processWordWrapBreakValue(wctx, line_break);
+                            if (wctx.failed) return;
+                        }
+                        for (info.wrap_breaks[word_idx..]) |wrap_break| {
+                            processWordWrapBreakValue(wctx, wrap_break);
+                            if (wctx.failed) return;
+                        }
                     }
-                    break :blk info.word_classes.last;
+                    break :blk info.word_classes;
                 } else blk: {
                     const streamed_layout = utf8.walkChunkLayoutInfoComptime(
                         chunk_bytes,
@@ -2040,7 +2107,7 @@ pub const UnifiedTextBufferView = struct {
                         wctx.failed = true;
                         return;
                     };
-                    break :blk streamed_layout.last;
+                    break :blk streamed_layout;
                 };
 
                 if (wctx.word_chunk_col_start < chunk.width_cols) {
@@ -2052,7 +2119,7 @@ pub const UnifiedTextBufferView = struct {
                         wctx.word_chunk_byte_start,
                         @intCast(chunk_bytes.len),
                     );
-                    if (!wctx.failed) wctx.pending_word_last_class = last_word_class;
+                    if (!wctx.failed) wctx.pending_word_edges = edges;
                     wctx.source_line_has_non_whitespace = true;
                 }
                 wctx.word_chunk = null;

--- a/packages/native/src/text-buffer-view.zig
+++ b/packages/native/src/text-buffer-view.zig
@@ -57,8 +57,9 @@ pub const SelectionRange = struct {
 
 /// Ghostty-style boundaries for double-click selection. NUL is omitted because
 /// OpenTUI text buffers do not use it for unwritten terminal cells.
-/// Keep this policy separate from `utf8.findWrapBreaks`: wrap and editor motion
-/// split on `/`, `-`, and CJK/ASCII transitions, but selection does not.
+/// Keep this policy separate from `utf8.findChunkLayoutInfo`: wrap and editor
+/// motion split on `/`, `-`, and CJK/ASCII transitions (wrap additionally
+/// between adjacent CJK characters), but selection does not.
 /// Selection groups consecutive graphemes by this class, so space and tab runs
 /// are selectable instead of mapping to an adjacent word.
 const default_word_boundaries = [_]u21{
@@ -2012,7 +2013,8 @@ pub const UnifiedTextBufferView = struct {
                 else
                     utf8.chunkWordClassEdges(chunk_bytes);
                 if (wctx.pending_word_width_cols > 0 and
-                    utf8.isCjkAsciiTransition(wctx.pending_word_last_class, word_classes.first))
+                    (utf8.isCjkAsciiTransition(wctx.pending_word_last_class, word_classes.first) or
+                        utf8.isCjkIntercharacterBreak(wctx.pending_word_last_class, word_classes.first)))
                 {
                     finalizePendingWord(wctx);
                     if (wctx.failed) return;

--- a/packages/native/src/text-buffer-view.zig
+++ b/packages/native/src/text-buffer-view.zig
@@ -58,8 +58,8 @@ pub const SelectionRange = struct {
 /// Ghostty-style boundaries for double-click selection. NUL is omitted because
 /// OpenTUI text buffers do not use it for unwritten terminal cells.
 /// Keep this policy separate from `utf8.findChunkLayoutInfo`: wrap and editor
-/// motion split on `/`, `-`, and CJK/ASCII transitions (wrap additionally
-/// between adjacent CJK characters), but selection does not.
+/// motion split on `/`, `-`, and CJK/ASCII transitions, but selection does not.
+/// Wrapping also permits breaks between adjacent CJK characters.
 /// Selection groups consecutive graphemes by this class, so space and tab runs
 /// are selectable instead of mapping to an adjacent word.
 const default_word_boundaries = [_]u21{
@@ -154,11 +154,6 @@ const PendingWordPiece = struct {
 const PendingWordPieceFit = struct {
     width_cols: u32,
     bytes_used: u32,
-};
-
-const PendingWordPrefixFit = struct {
-    full_pieces: usize,
-    last_piece: PendingWordPieceFit,
 };
 
 pub const VirtualLine = struct {
@@ -1581,20 +1576,20 @@ pub const UnifiedTextBufferView = struct {
             line_idx: u32 = 0,
             source_line_col_offset: u32 = 0,
             current_vline_width_cols: u32 = 0,
-            measure_has_content: if (calculation == .measure) bool else void = if (calculation == .measure) false else {},
             current_vline: if (calculation == .render) VirtualLine else void = if (calculation == .render) VirtualLine.init() else {},
             current_line_first_vline_idx: if (calculation == .render) u32 else void = if (calculation == .render) 0 else {},
             current_line_vline_count: if (calculation == .render) u32 else void = if (calculation == .render) 0 else {},
             pending_word_pieces: if (wrap_mode == .word) std.ArrayListUnmanaged(PendingWordPiece) else void = if (wrap_mode == .word) .empty else {},
             pending_word_width_cols: if (wrap_mode == .word) u32 else void = if (wrap_mode == .word) 0 else {},
-            // Index of the last piece joined to its predecessor; zero means no remaining split.
-            pending_word_last_split: if (wrap_mode == .word) usize else void = if (wrap_mode == .word) 0 else {},
-            pending_word_edges: if (wrap_mode == .word) utf8.WordClassEdges else void = if (wrap_mode == .word) .{ .first = .other, .last = .other } else {},
+            pending_word_last_class: if (wrap_mode == .word) utf8.WordClass else void = if (wrap_mode == .word) .other else {},
+            word_line_chunks: if (wrap_mode == .word) std.ArrayListUnmanaged(*const TextChunk) else void = if (wrap_mode == .word) .empty else {},
+            word_line_first_chunk: if (wrap_mode == .word) ?*const TextChunk else void = if (wrap_mode == .word) null else {},
+            word_line_last_cp: if (wrap_mode == .word) ?u21 else void = if (wrap_mode == .word) null else {},
+            source_line_cjk_breaks: if (wrap_mode == .word) bool else void = if (wrap_mode == .word) true else {},
             source_line_has_non_whitespace: if (wrap_mode == .word) bool else void = if (wrap_mode == .word) false else {},
             word_chunk: if (wrap_mode == .word) ?*const TextChunk else void = if (wrap_mode == .word) null else {},
             word_chunk_col_start: if (wrap_mode == .word) u32 else void = if (wrap_mode == .word) 0 else {},
             word_chunk_byte_start: if (wrap_mode == .word) u32 else void = if (wrap_mode == .word) 0 else {},
-            deferred_measure_chunk: if (wrap_mode == .word and calculation == .measure) ?*const TextChunk else void = if (wrap_mode == .word and calculation == .measure) null else {},
             logical_measure_line_count: if (wrap_mode == .word and calculation == .measure) u32 else void = if (wrap_mode == .word and calculation == .measure) 0 else {},
             logical_measure_width_max: if (wrap_mode == .word and calculation == .measure) u32 else void = if (wrap_mode == .word and calculation == .measure) 0 else {},
             failed: bool = false,
@@ -1623,7 +1618,6 @@ pub const UnifiedTextBufferView = struct {
                     wctx.current_vline.document_cell_offset = wctx.document_cell_offset;
                 }
                 wctx.current_vline_width_cols = 0;
-                if (comptime calculation == .measure) wctx.measure_has_content = false;
                 wctx.current_wrap_width = wctx.wrap_w;
             }
 
@@ -1647,7 +1641,6 @@ pub const UnifiedTextBufferView = struct {
 
             inline fn addVirtualChunk(wctx: *@This(), chunk: *const TextChunk, byte_start: u32, byte_len: u32, col_start: u32, width_cols: u32) Allocator.Error!void {
                 if (byte_len == 0) return;
-                if (comptime calculation == .measure) wctx.measure_has_content = true;
 
                 if (comptime calculation == .render and wrap_mode == .word) {
                     if (wctx.current_vline.chunks.items.len > 0) {
@@ -1703,7 +1696,7 @@ pub const UnifiedTextBufferView = struct {
             }
 
             fn queuePendingWordPiece(wctx: *@This(), chunk: *const TextChunk, col_start_in_chunk: u32, width_cols: u32, byte_start: u32, byte_end: u32) void {
-                if (byte_start == byte_end or wctx.failed) return;
+                if (width_cols == 0 or wctx.failed) return;
 
                 if (wctx.pending_word_pieces.items.len > 0) {
                     const last = &wctx.pending_word_pieces.items[wctx.pending_word_pieces.items.len - 1];
@@ -1731,8 +1724,7 @@ pub const UnifiedTextBufferView = struct {
             fn clearPendingWord(wctx: *@This()) void {
                 wctx.pending_word_pieces.clearRetainingCapacity();
                 wctx.pending_word_width_cols = 0;
-                wctx.pending_word_last_split = 0;
-                wctx.pending_word_edges = .{ .first = .other, .last = .other };
+                wctx.pending_word_last_class = .other;
             }
 
             fn dropPendingWordPrefix(wctx: *@This(), count: usize) void {
@@ -1746,7 +1738,6 @@ pub const UnifiedTextBufferView = struct {
                     );
                 }
                 wctx.pending_word_pieces.items.len = remaining;
-                wctx.pending_word_last_split -|= count;
             }
 
             fn fitPendingWordPiece(wctx: *@This(), piece: PendingWordPiece, max_width_cols: u32, allow_forced_grapheme: bool) PendingWordPieceFit {
@@ -1796,88 +1787,34 @@ pub const UnifiedTextBufferView = struct {
                 };
             }
 
-            fn fitPendingWordPrefix(wctx: *@This(), max_width_cols: u32) PendingWordPrefixFit {
-                // A public append may split a grapheme across chunks. Keep its
-                // exact byte boundary while retaining the chunks' source-column units.
-                var break_state: @import("uucode").grapheme.BreakState = .default;
-                var prev_cp: ?u21 = null;
-                var cols: u32 = 0;
-                var fit_cols: u32 = 0;
-                var fit: PendingWordPrefixFit = .{ .full_pieces = 0, .last_piece = .{ .width_cols = 0, .bytes_used = 0 } };
-                const width_method = wctx.text_buffer.widthMethod();
-                for (wctx.pending_word_pieces.items, 0..) |piece, piece_idx| {
-                    const bytes = piece.chunk.getBytes(wctx.text_buffer.memRegistry());
-                    var pos: usize = piece.byte_start;
-                    const cols_before_piece = cols;
-                    var width_state: utf8.GraphemeWidthState = undefined;
-                    var local_state: @import("uucode").grapheme.BreakState = .default;
-                    var local_prev_cp: ?u21 = null;
-                    while (pos < piece.byte_end) {
-                        const decoded = utf8.decodeUtf8Unchecked(bytes, pos);
-                        const is_break = utf8.isGraphemeBreak(prev_cp, decoded.cp, &break_state, width_method);
-                        if (is_break) {
-                            const boundary: PendingWordPrefixFit = .{
-                                .full_pieces = piece_idx,
-                                .last_piece = .{ .width_cols = cols - cols_before_piece, .bytes_used = @intCast(pos - piece.byte_start) },
-                            };
-                            if (cols > max_width_cols) return if (fit_cols > 0) fit else boundary;
-                            fit_cols = cols;
-                            fit = boundary;
-                        }
-                        const width = utf8.charWidth(bytes[pos], decoded.cp, wctx.text_buffer.tabWidth());
-                        if (utf8.isGraphemeBreak(local_prev_cp, decoded.cp, &local_state, width_method)) {
-                            width_state = .init(decoded.cp, width, width_method);
-                            cols += width_state.width;
-                        } else {
-                            const before = width_state.width;
-                            width_state.addCodepoint(decoded.cp, width);
-                            cols += width_state.width - before;
-                        }
-                        prev_cp = decoded.cp;
-                        local_prev_cp = decoded.cp;
-                        pos += decoded.len;
-                    }
-                }
-                return if (cols <= max_width_cols or fit_cols == 0)
-                    .{ .full_pieces = wctx.pending_word_pieces.items.len, .last_piece = .{ .width_cols = 0, .bytes_used = 0 } }
-                else
-                    fit;
-            }
-
             fn consumePendingWordPrefix(wctx: *@This(), max_width_cols: u32) bool {
                 if (max_width_cols == 0 or wctx.pending_word_width_cols == 0 or wctx.failed) return false;
 
                 const vline_width_cols_before = wctx.current_vline_width_cols;
-                const prefix_fit: ?PendingWordPrefixFit = if (wctx.pending_word_last_split > 0)
-                    fitPendingWordPrefix(wctx, max_width_cols)
-                else
-                    null;
                 var remaining_width_cols = max_width_cols;
                 var consumed_count: usize = 0;
-                while (consumed_count < wctx.pending_word_pieces.items.len) {
+                while (consumed_count < wctx.pending_word_pieces.items.len and remaining_width_cols > 0) {
                     const piece = wctx.pending_word_pieces.items[consumed_count];
-                    const fit = if (prefix_fit) |prefix| blk: {
-                        if (consumed_count < prefix.full_pieces) break :blk PendingWordPieceFit{ .width_cols = piece.width_cols, .bytes_used = piece.byte_end - piece.byte_start };
-                        break :blk prefix.last_piece;
-                    } else fitPendingWordPiece(wctx, piece, remaining_width_cols, wctx.current_vline_width_cols == vline_width_cols_before);
-                    if (fit.bytes_used == 0) break;
-                    if (!addVirtualChunkSticky(wctx, piece.chunk, piece.byte_start, fit.bytes_used, piece.col_start_in_chunk, fit.width_cols)) return false;
-                    remaining_width_cols -|= fit.width_cols;
-                    if (fit.bytes_used == piece.byte_end - piece.byte_start) {
+                    if (piece.width_cols <= remaining_width_cols) {
+                        if (!addVirtualChunkSticky(wctx, piece.chunk, piece.byte_start, piece.byte_end - piece.byte_start, piece.col_start_in_chunk, piece.width_cols)) return false;
+                        remaining_width_cols -= piece.width_cols;
                         consumed_count += 1;
                         continue;
                     }
 
+                    const fit = fitPendingWordPiece(wctx, piece, remaining_width_cols, wctx.current_vline_width_cols == vline_width_cols_before);
+                    if (fit.width_cols == 0) break;
+                    if (!addVirtualChunkSticky(wctx, piece.chunk, piece.byte_start, fit.bytes_used, piece.col_start_in_chunk, fit.width_cols)) return false;
                     wctx.pending_word_pieces.items[consumed_count].col_start_in_chunk += fit.width_cols;
                     wctx.pending_word_pieces.items[consumed_count].width_cols -= fit.width_cols;
                     wctx.pending_word_pieces.items[consumed_count].byte_start += fit.bytes_used;
+                    if (wctx.pending_word_pieces.items[consumed_count].width_cols == 0) consumed_count += 1;
                     break;
                 }
 
                 dropPendingWordPrefix(wctx, consumed_count);
                 const consumed_width_cols = wctx.current_vline_width_cols - vline_width_cols_before;
                 wctx.pending_word_width_cols -= consumed_width_cols;
-                if (wctx.pending_word_pieces.items.len == 0) clearPendingWord(wctx);
                 return consumed_width_cols > 0;
             }
 
@@ -1889,7 +1826,7 @@ pub const UnifiedTextBufferView = struct {
             }
 
             fn finalizePendingWord(wctx: *@This()) void {
-                while (wctx.pending_word_pieces.items.len > 0 and !wctx.failed) {
+                while (wctx.pending_word_width_cols > 0 and !wctx.failed) {
                     const wrap_limit_cols = wctx.wordWrapWidth();
                     if (wctx.current_vline_width_cols > 0 and wctx.current_vline_width_cols + wctx.pending_word_width_cols > wrap_limit_cols) {
                         if (!commitVirtualLineSticky(wctx)) return;
@@ -1935,7 +1872,7 @@ pub const UnifiedTextBufferView = struct {
 
             fn flushCompleteWordPiece(wctx: *@This(), chunk: *const TextChunk, col_start_in_chunk: u32, width_cols: u32, byte_start: u32, byte_end: u32) void {
                 if (width_cols == 0 or wctx.failed) return;
-                if (wctx.pending_word_pieces.items.len > 0) {
+                if (wctx.pending_word_width_cols > 0) {
                     queuePendingWordPiece(wctx, chunk, col_start_in_chunk, width_cols, byte_start, byte_end);
                     finalizePendingWord(wctx);
                 } else {
@@ -1963,7 +1900,7 @@ pub const UnifiedTextBufferView = struct {
                     );
                     if (wctx.failed) return;
                     wctx.source_line_has_non_whitespace = true;
-                } else if (wctx.pending_word_pieces.items.len > 0) {
+                } else if (wctx.pending_word_width_cols > 0) {
                     finalizePendingWord(wctx);
                     if (wctx.failed) return;
                 }
@@ -1993,6 +1930,7 @@ pub const UnifiedTextBufferView = struct {
             }
 
             inline fn processWordWrapBreakValue(wctx: *@This(), wrap_break: utf8.LayoutWrapBreak) void {
+                if (wrap_break.kind == .cjk_intercharacter and !wctx.source_line_cjk_breaks) return;
                 const chunk = wctx.word_chunk orelse return;
                 const chunk_bytes = chunk.getBytes(wctx.text_buffer.memRegistry());
                 const col_end = @min(wrap_break.colEnd(), chunk.width_cols);
@@ -2039,7 +1977,11 @@ pub const UnifiedTextBufferView = struct {
                 else blk: {
                     if (comptime calculation == .render) {
                         if (!chunk.isAsciiOnly() and chunk_bytes.len >= 1024 and chunk_bytes.len <= 64 * 1024) {
-                            break :blk wctx.text_buffer.getLayoutInfoFor(chunk) catch |err| switch (err) {
+                            const info = if (wctx.source_line_cjk_breaks)
+                                wctx.text_buffer.getLayoutInfoFor(chunk)
+                            else
+                                wctx.text_buffer.getWordLayoutInfoFor(chunk);
+                            break :blk info catch |err| switch (err) {
                                 error.OutOfMemory => null,
                                 else => {
                                     wctx.failed = true;
@@ -2078,61 +2020,36 @@ pub const UnifiedTextBufferView = struct {
                     info.word_classes
                 else
                     utf8.chunkWordClassEdges(chunk_bytes);
-                var continued_state: ?@import("uucode").grapheme.BreakState = null;
-                if (wctx.pending_word_pieces.items.len > 0 and chunk_bytes.len > 0) {
-                    var state = wctx.pending_word_edges.break_state;
-                    const first = utf8.decodeUtf8Unchecked(chunk_bytes, 0);
-                    const first_cp = first.cp;
-                    const is_break = (chunk.isAsciiOnly() and (wctx.pending_word_edges.last_cp orelse 0) < 0x80) or
-                        utf8.isGraphemeBreak(wctx.pending_word_edges.last_cp, first_cp, &state, wctx.text_buffer.widthMethod());
-                    if (!is_break) {
-                        wctx.pending_word_last_split = wctx.pending_word_pieces.items.len;
-                    } else if (utf8.isCjkAsciiTransition(wctx.pending_word_edges.last, word_classes.first) or
-                        utf8.isCjkIntercharacterBreak(wctx.pending_word_edges.last, word_classes.first, first_cp))
-                    {
-                        finalizePendingWord(wctx);
-                        if (wctx.failed) return;
-                    }
-                    // Carry context through a leading RI/ZWJ run until it agrees
-                    // with the chunk-local scan. The rest needs no second scan.
-                    var local_state: @import("uucode").grapheme.BreakState = .default;
-                    var prev_cp = first_cp;
-                    var pos: usize = first.len;
-                    while (state != local_state and pos < chunk_bytes.len) {
-                        const decoded = utf8.decodeUtf8Unchecked(chunk_bytes, pos);
-                        _ = utf8.isGraphemeBreak(prev_cp, decoded.cp, &state, wctx.text_buffer.widthMethod());
-                        _ = utf8.isGraphemeBreak(prev_cp, decoded.cp, &local_state, wctx.text_buffer.widthMethod());
-                        prev_cp = decoded.cp;
-                        pos += decoded.len;
-                    }
-                    if (state != local_state) continued_state = state;
+                if (wctx.pending_word_width_cols > 0 and
+                    (utf8.isCjkAsciiTransition(wctx.pending_word_last_class, word_classes.first) or
+                        (wctx.source_line_cjk_breaks and chunk_bytes.len > 0 and
+                            utf8.isCjkIntercharacterBreak(wctx.pending_word_last_class, word_classes.first, utf8.decodeUtf8Unchecked(chunk_bytes, 0).cp))))
+                {
+                    finalizePendingWord(wctx);
+                    if (wctx.failed) return;
                 }
                 wctx.word_chunk = chunk;
                 wctx.word_chunk_col_start = 0;
                 wctx.word_chunk_byte_start = 0;
-                const edges = if (layout) |info| blk: {
-                    if (info.wrap_breaks.len == 0 or info.cjk_breaks.len == 0) {
-                        const breaks = if (info.wrap_breaks.len == 0) info.cjk_breaks else info.wrap_breaks;
-                        for (breaks) |wrap_break| {
-                            processWordWrapBreakValue(wctx, wrap_break);
-                            if (wctx.failed) return;
-                        }
-                    } else {
-                        var word_idx: usize = 0;
-                        for (info.cjk_breaks) |line_break| {
-                            while (word_idx < info.wrap_breaks.len and info.wrap_breaks[word_idx].byte_start < line_break.byte_start) : (word_idx += 1) {
-                                processWordWrapBreakValue(wctx, info.wrap_breaks[word_idx]);
+                const last_word_class = if (layout) |info| blk: {
+                    var cjk_idx: usize = 0;
+                    for (info.wrap_breaks) |wrap_break| {
+                        if (wctx.source_line_cjk_breaks) {
+                            while (cjk_idx < info.cjk_breaks.len and info.cjk_breaks[cjk_idx].byte_start < wrap_break.byte_start) : (cjk_idx += 1) {
+                                processWordWrapBreakValue(wctx, info.cjk_breaks[cjk_idx]);
                                 if (wctx.failed) return;
                             }
-                            processWordWrapBreakValue(wctx, line_break);
-                            if (wctx.failed) return;
                         }
-                        for (info.wrap_breaks[word_idx..]) |wrap_break| {
+                        processWordWrapBreakValue(wctx, wrap_break);
+                        if (wctx.failed) return;
+                    }
+                    if (wctx.source_line_cjk_breaks) {
+                        for (info.cjk_breaks[cjk_idx..]) |wrap_break| {
                             processWordWrapBreakValue(wctx, wrap_break);
                             if (wctx.failed) return;
                         }
                     }
-                    break :blk info.word_classes;
+                    break :blk info.word_classes.last;
                 } else blk: {
                     const streamed_layout = utf8.walkChunkLayoutInfoComptime(
                         chunk_bytes,
@@ -2145,10 +2062,10 @@ pub const UnifiedTextBufferView = struct {
                         wctx.failed = true;
                         return;
                     };
-                    break :blk streamed_layout;
+                    break :blk streamed_layout.last;
                 };
 
-                if (wctx.word_chunk_byte_start < chunk_bytes.len) {
+                if (wctx.word_chunk_col_start < chunk.width_cols) {
                     queuePendingWordPiece(
                         wctx,
                         chunk,
@@ -2157,11 +2074,8 @@ pub const UnifiedTextBufferView = struct {
                         wctx.word_chunk_byte_start,
                         @intCast(chunk_bytes.len),
                     );
-                    if (!wctx.failed) {
-                        wctx.pending_word_edges = edges;
-                        if (continued_state) |state| wctx.pending_word_edges.break_state = state;
-                    }
-                    if (wctx.word_chunk_col_start < chunk.width_cols) wctx.source_line_has_non_whitespace = true;
+                    if (!wctx.failed) wctx.pending_word_last_class = last_word_class;
+                    wctx.source_line_has_non_whitespace = true;
                 }
                 wctx.word_chunk = null;
             }
@@ -2233,24 +2147,40 @@ pub const UnifiedTextBufferView = struct {
                 }
             }
 
-            fn segment_callback(ctx_ptr: *anyopaque, _: u32, chunk: *const TextChunk, chunk_idx_in_line: u32) void {
+            fn segment_callback(ctx_ptr: *anyopaque, _: u32, chunk: *const TextChunk, _: u32) void {
                 const wctx = @as(*@This(), @ptrCast(@alignCast(ctx_ptr)));
                 if (wctx.failed) return;
 
                 if (comptime wrap_mode == .word) {
-                    if (comptime calculation == .measure) {
-                        // Only an unfragmented logical line can reuse one chunk's
-                        // summary; boundaries between chunks may join words.
-                        if (wctx.deferred_measure_chunk) |deferred| {
-                            processWordChunk(wctx, deferred);
-                            wctx.deferred_measure_chunk = null;
-                            if (wctx.failed) return;
-                        } else if (chunk_idx_in_line == 0) {
-                            wctx.deferred_measure_chunk = chunk;
-                            return;
-                        }
+                    // Decide the policy before emitting any CJK opportunities. Retain
+                    // only this line's chunk pointers, without rescanning its bytes.
+                    if (wctx.word_line_first_chunk == null) {
+                        wctx.word_line_first_chunk = chunk;
+                        return;
                     }
-                    processWordChunk(wctx, chunk);
+                    wctx.word_line_chunks.append(wctx.allocator, chunk) catch {
+                        wctx.failed = true;
+                        return;
+                    };
+                    const bytes = chunk.getBytes(wctx.text_buffer.memRegistry());
+                    if (wctx.source_line_cjk_breaks and bytes.len > 0) {
+                        if (wctx.word_line_last_cp == null) {
+                            const first_bytes = wctx.word_line_first_chunk.?.getBytes(wctx.text_buffer.memRegistry());
+                            wctx.word_line_last_cp = utf8.chunkWordClassEdges(first_bytes).last_cp;
+                        }
+                        const first_cp = utf8.decodeUtf8Unchecked(bytes, 0).cp;
+                        if (wctx.word_line_last_cp) |last_cp| {
+                            // Uncertain incoming state keeps the existing word policy.
+                            inline for (std.meta.tags(@import("uucode").grapheme.BreakState)) |initial_state| {
+                                var state = initial_state;
+                                if (!utf8.isGraphemeBreak(last_cp, first_cp, &state, wctx.text_buffer.widthMethod())) {
+                                    wctx.source_line_cjk_breaks = false;
+                                    break;
+                                }
+                            }
+                        }
+                        wctx.word_line_last_cp = utf8.chunkWordClassEdges(bytes).last_cp;
+                    }
                 } else {
                     const process_result = switch (wctx.text_buffer.widthMethod()) {
                         inline else => |width_method| processCharChunk(width_method, wctx, chunk),
@@ -2269,8 +2199,8 @@ pub const UnifiedTextBufferView = struct {
                 var measure_cache_chunk: ?*const TextChunk = null;
                 var measure_cache_first_width: u32 = 0;
                 if (comptime wrap_mode == .word and calculation == .measure) {
-                    if (wctx.deferred_measure_chunk) |chunk| {
-                        wctx.deferred_measure_chunk = null;
+                    if (wctx.word_line_first_chunk != null and wctx.word_line_chunks.items.len == 0) {
+                        const chunk = wctx.word_line_first_chunk.?;
                         measure_cache_chunk = chunk;
                         const first_width = wctx.lineWrapWidth();
                         measure_cache_first_width = first_width;
@@ -2284,22 +2214,31 @@ pub const UnifiedTextBufferView = struct {
                             wctx.result.width_cols_max = @max(wctx.result.width_cols_max, summary.width_max);
                             wctx.document_cell_offset += chunk.width_cols;
                             used_measure_cache = true;
-                        } else {
-                            processWordChunk(wctx, chunk);
-                            if (wctx.failed) return;
                         }
                     }
                 }
 
                 if (comptime wrap_mode == .word) {
-                    if (!used_measure_cache) finalizePendingWord(wctx);
+                    if (!used_measure_cache) {
+                        if (wctx.word_line_first_chunk) |chunk| {
+                            processWordChunk(wctx, chunk);
+                            if (wctx.failed) return;
+                        }
+                        for (wctx.word_line_chunks.items) |chunk| {
+                            processWordChunk(wctx, chunk);
+                            if (wctx.failed) return;
+                        }
+                        finalizePendingWord(wctx);
+                    }
                     clearPendingWord(wctx);
+                    wctx.word_line_first_chunk = null;
+                    wctx.word_line_chunks.clearRetainingCapacity();
                 }
 
                 const has_content = if (comptime calculation == .render)
                     wctx.current_vline.chunks.items.len > 0
                 else
-                    wctx.measure_has_content;
+                    wctx.current_vline_width_cols > 0;
                 if (!used_measure_cache and (has_content or line_info.width_cols == 0)) {
                     if (comptime calculation == .render) {
                         wctx.current_vline.width_cols = wctx.current_vline_width_cols;
@@ -2355,7 +2294,6 @@ pub const UnifiedTextBufferView = struct {
                 wctx.line_idx += 1;
                 wctx.source_line_col_offset = 0;
                 wctx.current_vline_width_cols = 0;
-                if (comptime calculation == .measure) wctx.measure_has_content = false;
                 wctx.current_wrap_width = wctx.wrap_w;
                 if (comptime calculation == .render) {
                     wctx.current_vline = VirtualLine.init();
@@ -2363,7 +2301,11 @@ pub const UnifiedTextBufferView = struct {
                     wctx.current_line_first_vline_idx = @intCast(wctx.result.virtual_lines.items.len);
                     wctx.current_line_vline_count = 0;
                 }
-                if (comptime wrap_mode == .word) wctx.source_line_has_non_whitespace = false;
+                if (comptime wrap_mode == .word) {
+                    wctx.source_line_has_non_whitespace = false;
+                    wctx.source_line_cjk_breaks = true;
+                    wctx.word_line_last_cp = null;
+                }
                 if (comptime wrap_mode == .word and calculation == .measure) {
                     wctx.logical_measure_line_count = 0;
                     wctx.logical_measure_width_max = 0;
@@ -2385,11 +2327,13 @@ pub const UnifiedTextBufferView = struct {
                 wrap_w,
         };
 
-        // Preserve unchanged chunks across edits; discard detached/history layouts
-        // only after the current rope has marked the caches it still uses.
+        defer if (comptime wrap_mode == .word) wrap_ctx.word_line_chunks.deinit(allocator);
+        // Retain unchanged chunks and reclaim layouts detached by incremental edits.
         if (comptime calculation == .render and wrap_mode == .word) text_buffer.layout_cache.beginLayout();
         text_buffer.walkLinesAndSegments(&wrap_ctx, WrapContext.segment_callback, WrapContext.line_end_callback);
+        // Failed traversal leaves live chunks unmarked; sibling views may still borrow them.
+        if (wrap_ctx.failed) return false;
         if (comptime calculation == .render and wrap_mode == .word) text_buffer.layout_cache.endLayout();
-        return !wrap_ctx.failed;
+        return true;
     }
 };

--- a/packages/native/src/text-buffer.zig
+++ b/packages/native/src/text-buffer.zig
@@ -213,7 +213,7 @@ pub const UnifiedTextBuffer = struct {
         return chunk.getLayoutInfo(self.allocator, @constCast(&self.layout_cache), &self.mem_registry, self.tab_width, self.width_method);
     }
 
-    pub fn getWordLayoutInfoFor(self: *const Self, chunk: *const TextChunk) TextBufferError!seg_mod.WordLayoutInfo {
+    pub fn getWordLayoutInfoFor(self: *const Self, chunk: *const TextChunk) TextBufferError!seg_mod.ChunkLayoutInfo {
         return chunk.getWordLayoutInfo(self.allocator, @constCast(&self.layout_cache), &self.mem_registry, self.tab_width, self.width_method);
     }
 

--- a/packages/native/src/text-buffer.zig
+++ b/packages/native/src/text-buffer.zig
@@ -63,6 +63,7 @@ pub const UnifiedTextBuffer = struct {
     allocator: Allocator,
     global_allocator: Allocator,
     arena: *std.heap.ArenaAllocator,
+    layout_cache: seg_mod.ChunkLayoutCache,
 
     _rope: UnifiedRope,
     syntax_style: ?*const SyntaxStyle,
@@ -209,11 +210,11 @@ pub const UnifiedTextBuffer = struct {
     }
 
     pub fn getLayoutInfoFor(self: *const Self, chunk: *const TextChunk) TextBufferError!seg_mod.ChunkLayoutInfo {
-        return chunk.getLayoutInfo(self.allocator, &self.mem_registry, self.tab_width, self.width_method);
+        return chunk.getLayoutInfo(self.allocator, @constCast(&self.layout_cache), &self.mem_registry, self.tab_width, self.width_method);
     }
 
     pub fn getWordLayoutInfoFor(self: *const Self, chunk: *const TextChunk) TextBufferError!seg_mod.WordLayoutInfo {
-        return chunk.getWordLayoutInfo(self.allocator, &self.mem_registry, self.tab_width, self.width_method);
+        return chunk.getWordLayoutInfo(self.allocator, @constCast(&self.layout_cache), &self.mem_registry, self.tab_width, self.width_method);
     }
 
     /// Accessor: walk all lines and segments via callbacks.
@@ -263,6 +264,7 @@ pub const UnifiedTextBuffer = struct {
             .allocator = internal_allocator,
             .global_allocator = global_allocator,
             .arena = internal_arena,
+            .layout_cache = .{ .allocator = global_allocator },
             ._rope = init_rope,
             .syntax_style = null,
             .pool = pool,
@@ -323,6 +325,7 @@ pub const UnifiedTextBuffer = struct {
         }
 
         self.mem_registry.deinit();
+        self.layout_cache.clear();
         self.arena.deinit();
         global_allocator.destroy(self.arena);
         self.* = undefined;
@@ -412,12 +415,14 @@ pub const UnifiedTextBuffer = struct {
     /// Use this for frequent text updates where undo/redo history should be preserved.
     pub fn clear(self: *Self) void {
         self.clearLinkRefs();
+        self.layout_cache.clear();
         self._rope.clear();
         self.markAllViewsDirty();
     }
 
     pub fn reset(self: *Self) void {
         self.clearLinkRefs();
+        self.layout_cache.clear();
 
         // Free highlight/span arrays (they use global_allocator, not arena)
         for (self.line_highlights.items) |*hl_list| {

--- a/packages/native/src/text-buffer.zig
+++ b/packages/native/src/text-buffer.zig
@@ -212,6 +212,10 @@ pub const UnifiedTextBuffer = struct {
         return chunk.getLayoutInfo(self.allocator, &self.mem_registry, self.tab_width, self.width_method);
     }
 
+    pub fn getWordLayoutInfoFor(self: *const Self, chunk: *const TextChunk) TextBufferError!seg_mod.WordLayoutInfo {
+        return chunk.getWordLayoutInfo(self.allocator, &self.mem_registry, self.tab_width, self.width_method);
+    }
+
     /// Accessor: walk all lines and segments via callbacks.
     pub fn walkLinesAndSegments(
         self: *const Self,

--- a/packages/native/src/text-buffer.zig
+++ b/packages/native/src/text-buffer.zig
@@ -213,7 +213,7 @@ pub const UnifiedTextBuffer = struct {
         return chunk.getLayoutInfo(self.allocator, @constCast(&self.layout_cache), &self.mem_registry, self.tab_width, self.width_method);
     }
 
-    pub fn getWordLayoutInfoFor(self: *const Self, chunk: *const TextChunk) TextBufferError!seg_mod.ChunkLayoutInfo {
+    pub fn getWordLayoutInfoFor(self: *const Self, chunk: *const TextChunk) TextBufferError!seg_mod.WordLayoutInfo {
         return chunk.getWordLayoutInfo(self.allocator, @constCast(&self.layout_cache), &self.mem_registry, self.tab_width, self.width_method);
     }
 

--- a/packages/native/src/utf8.zig
+++ b/packages/native/src/utf8.zig
@@ -111,13 +111,14 @@ pub const LayoutWrapBreakKind = enum(u8) {
     preserved_whitespace,
     punctuation,
     script_transition,
+    cjk_intercharacter,
 
     /// True when the break also ends a word. Word motion must skip breaks
     /// that are line-break opportunities only.
     pub fn isWordBoundary(self: LayoutWrapBreakKind) bool {
         return switch (self) {
             .whitespace, .punctuation, .script_transition => true,
-            .none => false,
+            .none, .cjk_intercharacter => false,
         };
     }
 };
@@ -267,6 +268,13 @@ inline fn classifyWordClass(cp: u21) WordClass {
 
 pub inline fn isWordCodepoint(cp: u21) bool {
     return classifyWordClass(cp) != .other;
+}
+
+/// CJK text has no spaces between words, so any two adjacent CJK characters
+/// form a line-break opportunity. The run still moves as one word; see
+/// LayoutWrapBreakKind.isWordBoundary.
+pub inline fn isCjkIntercharacterBreak(prev_class: WordClass, curr_class: WordClass) bool {
+    return prev_class == .cjk_word and curr_class == .cjk_word;
 }
 
 pub inline fn isCjkAsciiTransition(prev_class: WordClass, curr_class: WordClass) bool {
@@ -1550,12 +1558,13 @@ inline fn commitLayoutCluster(
     cluster_class: WordClass,
     next_class: ?WordClass,
 ) !bool {
-    const kind: LayoutWrapBreakKind = if (cluster_break_kind != .none)
-        cluster_break_kind
-    else if (next_class != null and isCjkAsciiTransition(cluster_class, next_class.?))
-        .script_transition
-    else
-        .none;
+    const kind: LayoutWrapBreakKind = blk: {
+        if (cluster_break_kind != .none) break :blk cluster_break_kind;
+        const next = next_class orelse break :blk .none;
+        if (isCjkAsciiTransition(cluster_class, next)) break :blk .script_transition;
+        if (isCjkIntercharacterBreak(cluster_class, next)) break :blk .cjk_intercharacter;
+        break :blk .none;
+    };
     if (kind != .none) {
         return emitLayoutWrapBreak(
             visitor,

--- a/packages/native/src/utf8.zig
+++ b/packages/native/src/utf8.zig
@@ -102,17 +102,31 @@ pub const TabStopResult = struct {
     }
 };
 
+/// Classifies a layout break opportunity. Line wrapping and editor word motion
+/// share the same scan, but the two boundary sets differ: every kind is a
+/// line-break opportunity, while only word-ending kinds are word boundaries.
 pub const LayoutWrapBreakKind = enum(u8) {
     none,
     whitespace,
     preserved_whitespace,
     punctuation,
     script_transition,
+
+    /// True when the break also ends a word. Word motion must skip breaks
+    /// that are line-break opportunities only.
+    pub fn isWordBoundary(self: LayoutWrapBreakKind) bool {
+        return switch (self) {
+            .whitespace, .punctuation, .script_transition => true,
+            .none => false,
+        };
+    }
 };
 
 /// Direct byte and display-column metadata for a wrap opportunity.
 /// The window identifies the grapheme that creates the break, not the position
 /// after it; consumers use byteEnd()/colEnd() to cross the boundary.
+/// Line wrapping may break at every entry; word motion must filter through
+/// `kind.isWordBoundary()`.
 pub const LayoutWrapBreak = struct {
     byte_start: u32,
     col_start: u32,

--- a/packages/native/src/utf8.zig
+++ b/packages/native/src/utf8.zig
@@ -117,7 +117,7 @@ pub const LayoutWrapBreakKind = enum(u8) {
     /// that are line-break opportunities only.
     pub fn isWordBoundary(self: LayoutWrapBreakKind) bool {
         return switch (self) {
-            .whitespace, .punctuation, .script_transition => true,
+            .whitespace, .preserved_whitespace, .punctuation, .script_transition => true,
             .none, .cjk_intercharacter => false,
         };
     }
@@ -528,7 +528,7 @@ inline fn asciiCharWidth(byte: u8, tab_width: u8) u32 {
 }
 
 /// Calculate the display width of a character (byte or codepoint) in columns
-inline fn charWidth(byte: u8, codepoint: u21, tab_width: u8) u32 {
+pub inline fn charWidth(byte: u8, codepoint: u21, tab_width: u8) u32 {
     if (byte == '\t') {
         return tab_width;
     } else if (byte < 0x80 and byte >= 32 and byte <= 126) {
@@ -552,7 +552,7 @@ inline fn isValidCodepoint(cp: u21) bool {
 ///   but calculate width using wcwidth (sum of codepoint widths)
 /// - no_zwj mode: use grapheme breaks but treat ZWJ as a break (ignore joining)
 /// - unicode mode: use standard grapheme cluster segmentation
-inline fn isGraphemeBreak(prev_cp: ?u21, curr_cp: u21, break_state: *uucode.grapheme.BreakState, width_method: WidthMethod) bool {
+pub inline fn isGraphemeBreak(prev_cp: ?u21, curr_cp: u21, break_state: *uucode.grapheme.BreakState, width_method: WidthMethod) bool {
     // wcwidth mode uses Unicode grapheme clustering for proper rendering
     // (ZWJ sequences, skin tone modifiers stay together), but width is
     // calculated using wcwidth semantics (sum of codepoint widths)
@@ -592,7 +592,7 @@ inline fn isGraphemeBreak(prev_cp: ?u21, curr_cp: u21, break_state: *uucode.grap
 }
 
 /// State for accumulating grapheme cluster width
-const GraphemeWidthState = struct {
+pub const GraphemeWidthState = struct {
     width: u32 = 0,
     has_width: bool = false,
     is_regional_indicator_pair: bool = false,
@@ -601,7 +601,7 @@ const GraphemeWidthState = struct {
     width_method: WidthMethod,
 
     /// Initialize state with the first codepoint of a grapheme cluster
-    inline fn init(first_cp: u21, first_width: u32, width_method: WidthMethod) GraphemeWidthState {
+    pub inline fn init(first_cp: u21, first_width: u32, width_method: WidthMethod) GraphemeWidthState {
         return .{
             .width = first_width,
             .has_width = (first_width > 0),
@@ -613,7 +613,7 @@ const GraphemeWidthState = struct {
     }
 
     /// Add a codepoint to the current grapheme cluster
-    inline fn addCodepoint(self: *GraphemeWidthState, cp: u21, cp_width: u32) void {
+    pub inline fn addCodepoint(self: *GraphemeWidthState, cp: u21, cp_width: u32) void {
         // wcwidth mode: sum all codepoint widths (tmux-style)
         if (self.width_method == .wcwidth) {
             const eaw = uucode.get(.east_asian_width, cp);
@@ -1510,13 +1510,24 @@ pub const RenderClusterInfo = struct {
 };
 
 pub const ChunkLayoutInfo = struct {
+    // Individually ordered lists; wrapping merges them, word motion uses only the first.
     wrap_breaks: []const LayoutWrapBreak,
+    cjk_breaks: []const LayoutWrapBreak = &.{},
     word_classes: WordClassEdges,
 };
 
-// Edge classes preserve CJK/ASCII transition boundaries across rope chunks.
-pub const WordClassEdges = struct { first: WordClass, last: WordClass };
+// Preserve script and grapheme boundaries across rope chunks. A chunk edge
+// inside a grapheme is not a wrapping opportunity, regardless of its script.
+pub const WordClassEdges = struct {
+    first: WordClass,
+    last: WordClass,
+    last_cp: ?u21 = null,
+    break_state: uucode.grapheme.BreakState = .default,
+    has_cjk_breaks: bool = false,
+};
 
+// Cheap endpoint classes; trailing grapheme state and interior opportunities
+// are supplied by the full layout scan.
 pub fn chunkWordClassEdges(text: []const u8) WordClassEdges {
     if (text.len == 0) return .{ .first = .other, .last = .other };
 
@@ -1528,7 +1539,7 @@ pub fn chunkWordClassEdges(text: []const u8) WordClassEdges {
         continuation_count += 1;
     }
     const last = decodeUtf8Unchecked(text, last_start).cp;
-    return .{ .first = classifyWordClass(first), .last = classifyWordClass(last) };
+    return .{ .first = classifyWordClass(first), .last = classifyWordClass(last), .last_cp = last };
 }
 
 inline fn emitLayoutWrapBreak(
@@ -1557,12 +1568,16 @@ inline fn commitLayoutCluster(
     cluster_break_kind: LayoutWrapBreakKind,
     cluster_class: WordClass,
     next_class: ?WordClass,
+    has_cjk_breaks: *bool,
 ) !bool {
     const kind: LayoutWrapBreakKind = blk: {
         if (cluster_break_kind != .none) break :blk cluster_break_kind;
         const next = next_class orelse break :blk .none;
         if (isCjkAsciiTransition(cluster_class, next)) break :blk .script_transition;
-        if (isCjkIntercharacterBreak(cluster_class, next)) break :blk .cjk_intercharacter;
+        if (isCjkIntercharacterBreak(cluster_class, next)) {
+            has_cjk_breaks.* = true;
+            if (!@TypeOf(visitor).word_only) break :blk .cjk_intercharacter;
+        }
         break :blk .none;
     };
     if (kind != .none) {
@@ -1642,6 +1657,59 @@ pub fn findChunkLayoutInfo(
     return walkChunkLayoutInfoComptime(text, tab_width, isASCIIOnly, width_method, &ctx, Context.append);
 }
 
+/// Editor queries do not need to materialize line-only CJK opportunities.
+pub fn findWordChunkLayoutInfo(
+    allocator: std.mem.Allocator,
+    text: []const u8,
+    tab_width: u8,
+    isASCIIOnly: bool,
+    width_method: WidthMethod,
+    wrap_breaks: *std.ArrayListUnmanaged(LayoutWrapBreak),
+) !WordClassEdges {
+    wrap_breaks.clearRetainingCapacity();
+    const Visitor = struct {
+        const word_only = true;
+        allocator: std.mem.Allocator,
+        breaks: *std.ArrayListUnmanaged(LayoutWrapBreak),
+
+        inline fn emit(self: @This(), wrap_break: LayoutWrapBreak) !bool {
+            try self.breaks.append(self.allocator, wrap_break);
+            return true;
+        }
+    };
+    return walkChunkLayoutInfoGeneric(text, tab_width, isASCIIOnly, width_method, Visitor{ .allocator = allocator, .breaks = wrap_breaks });
+}
+
+/// Retained layout stores word and line-only breaks once, in disjoint lists.
+pub fn findLineAndWordChunkLayoutInfo(
+    allocator: std.mem.Allocator,
+    text: []const u8,
+    tab_width: u8,
+    isASCIIOnly: bool,
+    width_method: WidthMethod,
+    line_breaks: *std.ArrayListUnmanaged(LayoutWrapBreak),
+    word_breaks: *std.ArrayListUnmanaged(LayoutWrapBreak),
+) !WordClassEdges {
+    line_breaks.clearRetainingCapacity();
+    word_breaks.clearRetainingCapacity();
+    const Visitor = struct {
+        const word_only = false;
+        allocator: std.mem.Allocator,
+        lines: *std.ArrayListUnmanaged(LayoutWrapBreak),
+        words: *std.ArrayListUnmanaged(LayoutWrapBreak),
+
+        inline fn emit(self: @This(), wrap_break: LayoutWrapBreak) !bool {
+            if (wrap_break.kind.isWordBoundary()) {
+                try self.words.append(self.allocator, wrap_break);
+            } else {
+                try self.lines.append(self.allocator, wrap_break);
+            }
+            return true;
+        }
+    };
+    return walkChunkLayoutInfoGeneric(text, tab_width, isASCIIOnly, width_method, Visitor{ .allocator = allocator, .lines = line_breaks, .words = word_breaks });
+}
+
 pub inline fn walkChunkLayoutInfoComptime(
     text: []const u8,
     tab_width: u8,
@@ -1651,6 +1719,7 @@ pub inline fn walkChunkLayoutInfoComptime(
     comptime callback: anytype,
 ) !WordClassEdges {
     const Visitor = struct {
+        const word_only = false;
         context: @TypeOf(context),
 
         inline fn emit(self: @This(), wrap_break: LayoutWrapBreak) !bool {
@@ -1675,6 +1744,7 @@ fn walkChunkLayoutInfoGeneric(
     }
 
     const first_word_class = classifyWordClass(decodeUtf8Unchecked(text, 0).cp);
+    var has_cjk_breaks = false;
 
     const vector_len = 16;
     var pos: usize = 0;
@@ -1719,6 +1789,7 @@ fn walkChunkLayoutInfoGeneric(
                             cluster_break_kind,
                             cluster_class,
                             first_class,
+                            &has_cjk_breaks,
                         )) return chunkWordClassEdges(text);
                         col += cluster_width_state.width;
                         cluster_started = false;
@@ -1774,6 +1845,7 @@ fn walkChunkLayoutInfoGeneric(
                     cluster_break_kind,
                     cluster_class,
                     curr_class,
+                    &has_cjk_breaks,
                 )) return chunkWordClassEdges(text);
                 col += cluster_width_state.width;
             }
@@ -1810,10 +1882,11 @@ fn walkChunkLayoutInfoGeneric(
             cluster_break_kind,
             cluster_class,
             null,
+            &has_cjk_breaks,
         );
     }
 
-    return .{ .first = first_word_class, .last = if (cluster_started) cluster_class else .other };
+    return .{ .first = first_word_class, .last = if (cluster_started) cluster_class else .other, .last_cp = prev_cp, .break_state = break_state, .has_cjk_breaks = has_cjk_breaks };
 }
 
 /// Find sparse render-cluster metadata for multibyte clusters and tabs.

--- a/packages/native/src/utf8.zig
+++ b/packages/native/src/utf8.zig
@@ -166,7 +166,8 @@ inline fn asciiLayoutWrapBreakKind(b: u8) LayoutWrapBreakKind {
 
 // Decode a UTF-8 codepoint starting at pos. Assumes valid UTF-8 input.
 // Returns (codepoint, length). If the remaining bytes are insufficient, returns length 1.
-pub inline fn decodeUtf8Unchecked(text: []const u8, pos: usize) struct { cp: u21, len: u3 } {
+// A full-word result avoids partial-width stores when materialized in hot loops.
+pub inline fn decodeUtf8Unchecked(text: []const u8, pos: usize) packed struct(u32) { cp: u21, len: u3, _padding: u8 = 0 } {
     const b0 = text[pos];
     if (b0 < 0x80) return .{ .cp = @intCast(b0), .len = 1 };
 
@@ -1823,14 +1824,8 @@ fn walkChunkLayoutInfoGeneric(
         }
 
         const b0 = text[pos];
-        const Decoded = struct { cp: u21, len: usize };
-        const decoded: Decoded = if (b0 < 0x80)
-            .{ .cp = @as(u21, b0), .len = @as(usize, 1) }
-        else blk: {
-            const value = decodeUtf8Unchecked(text, pos);
-            const len: usize = value.len;
-            break :blk .{ .cp = value.cp, .len = if (pos + len <= text.len) len else 1 };
-        };
+        const decoded = decodeUtf8Unchecked(text, pos);
+        std.debug.assert(decoded.len > 0 and decoded.len <= text.len - pos);
         const curr_class = classifyWordClass(decoded.cp);
         const is_break = isGraphemeBreak(prev_cp, decoded.cp, &break_state, width_method);
         const cp_width = charWidth(b0, decoded.cp, tab_width);

--- a/packages/native/src/utf8.zig
+++ b/packages/native/src/utf8.zig
@@ -273,8 +273,9 @@ pub inline fn isWordCodepoint(cp: u21) bool {
 /// CJK text has no spaces between words, so any two adjacent CJK characters
 /// form a line-break opportunity. The run still moves as one word; see
 /// LayoutWrapBreakKind.isWordBoundary.
-pub inline fn isCjkIntercharacterBreak(prev_class: WordClass, curr_class: WordClass) bool {
-    return prev_class == .cjk_word and curr_class == .cjk_word;
+pub inline fn isCjkIntercharacterBreak(prev_class: WordClass, curr_class: WordClass, curr_cp: u21) bool {
+    // These Katakana punctuation marks belong to editor words, but cannot start a line.
+    return prev_class == .cjk_word and curr_class == .cjk_word and curr_cp != 0x30A0 and curr_cp != 0x30FB;
 }
 
 pub inline fn isCjkAsciiTransition(prev_class: WordClass, curr_class: WordClass) bool {
@@ -1568,13 +1569,14 @@ inline fn commitLayoutCluster(
     cluster_break_kind: LayoutWrapBreakKind,
     cluster_class: WordClass,
     next_class: ?WordClass,
+    next_cp: u21,
     has_cjk_breaks: *bool,
 ) !bool {
     const kind: LayoutWrapBreakKind = blk: {
         if (cluster_break_kind != .none) break :blk cluster_break_kind;
         const next = next_class orelse break :blk .none;
         if (isCjkAsciiTransition(cluster_class, next)) break :blk .script_transition;
-        if (isCjkIntercharacterBreak(cluster_class, next)) {
+        if (cluster_width > 0 and isCjkIntercharacterBreak(cluster_class, next, next_cp)) {
             has_cjk_breaks.* = true;
             if (!@TypeOf(visitor).word_only) break :blk .cjk_intercharacter;
         }
@@ -1789,6 +1791,7 @@ fn walkChunkLayoutInfoGeneric(
                             cluster_break_kind,
                             cluster_class,
                             first_class,
+                            text[pos],
                             &has_cjk_breaks,
                         )) return chunkWordClassEdges(text);
                         col += cluster_width_state.width;
@@ -1845,6 +1848,7 @@ fn walkChunkLayoutInfoGeneric(
                     cluster_break_kind,
                     cluster_class,
                     curr_class,
+                    decoded.cp,
                     &has_cjk_breaks,
                 )) return chunkWordClassEdges(text);
                 col += cluster_width_state.width;
@@ -1882,6 +1886,7 @@ fn walkChunkLayoutInfoGeneric(
             cluster_break_kind,
             cluster_class,
             null,
+            0,
             &has_cjk_breaks,
         );
     }

--- a/packages/native/src/utf8.zig
+++ b/packages/native/src/utf8.zig
@@ -274,8 +274,9 @@ pub inline fn isWordCodepoint(cp: u21) bool {
 /// form a line-break opportunity. The run still moves as one word; see
 /// LayoutWrapBreakKind.isWordBoundary.
 pub inline fn isCjkIntercharacterBreak(prev_class: WordClass, curr_class: WordClass, curr_cp: u21) bool {
-    // These Katakana punctuation marks belong to editor words, but cannot start a line.
-    return prev_class == .cjk_word and curr_class == .cjk_word and curr_cp != 0x30A0 and curr_cp != 0x30FB;
+    // Kana punctuation and combining marks belong to editor words, not new line starts.
+    return prev_class == .cjk_word and curr_class == .cjk_word and
+        curr_cp != 0x3099 and curr_cp != 0x309A and curr_cp != 0x30A0 and curr_cp != 0x30FB;
 }
 
 pub inline fn isCjkAsciiTransition(prev_class: WordClass, curr_class: WordClass) bool {
@@ -529,7 +530,7 @@ inline fn asciiCharWidth(byte: u8, tab_width: u8) u32 {
 }
 
 /// Calculate the display width of a character (byte or codepoint) in columns
-pub inline fn charWidth(byte: u8, codepoint: u21, tab_width: u8) u32 {
+inline fn charWidth(byte: u8, codepoint: u21, tab_width: u8) u32 {
     if (byte == '\t') {
         return tab_width;
     } else if (byte < 0x80 and byte >= 32 and byte <= 126) {
@@ -593,7 +594,7 @@ pub inline fn isGraphemeBreak(prev_cp: ?u21, curr_cp: u21, break_state: *uucode.
 }
 
 /// State for accumulating grapheme cluster width
-pub const GraphemeWidthState = struct {
+const GraphemeWidthState = struct {
     width: u32 = 0,
     has_width: bool = false,
     is_regional_indicator_pair: bool = false,
@@ -602,7 +603,7 @@ pub const GraphemeWidthState = struct {
     width_method: WidthMethod,
 
     /// Initialize state with the first codepoint of a grapheme cluster
-    pub inline fn init(first_cp: u21, first_width: u32, width_method: WidthMethod) GraphemeWidthState {
+    inline fn init(first_cp: u21, first_width: u32, width_method: WidthMethod) GraphemeWidthState {
         return .{
             .width = first_width,
             .has_width = (first_width > 0),
@@ -614,7 +615,7 @@ pub const GraphemeWidthState = struct {
     }
 
     /// Add a codepoint to the current grapheme cluster
-    pub inline fn addCodepoint(self: *GraphemeWidthState, cp: u21, cp_width: u32) void {
+    inline fn addCodepoint(self: *GraphemeWidthState, cp: u21, cp_width: u32) void {
         // wcwidth mode: sum all codepoint widths (tmux-style)
         if (self.width_method == .wcwidth) {
             const eaw = uucode.get(.east_asian_width, cp);
@@ -1517,18 +1518,15 @@ pub const ChunkLayoutInfo = struct {
     word_classes: WordClassEdges,
 };
 
-// Preserve script and grapheme boundaries across rope chunks. A chunk edge
-// inside a grapheme is not a wrapping opportunity, regardless of its script.
+// Endpoint classes and codepoints support script transitions and chunk-edge checks.
 pub const WordClassEdges = struct {
     first: WordClass,
     last: WordClass,
     last_cp: ?u21 = null,
-    break_state: uucode.grapheme.BreakState = .default,
     has_cjk_breaks: bool = false,
 };
 
-// Cheap endpoint classes; trailing grapheme state and interior opportunities
-// are supplied by the full layout scan.
+// Cheap endpoint metadata without scanning the chunk contents.
 pub fn chunkWordClassEdges(text: []const u8) WordClassEdges {
     if (text.len == 0) return .{ .first = .other, .last = .other };
 
@@ -1891,7 +1889,7 @@ fn walkChunkLayoutInfoGeneric(
         );
     }
 
-    return .{ .first = first_word_class, .last = if (cluster_started) cluster_class else .other, .last_cp = prev_cp, .break_state = break_state, .has_cjk_breaks = has_cjk_breaks };
+    return .{ .first = first_word_class, .last = if (cluster_started) cluster_class else .other, .last_cp = prev_cp, .has_cjk_breaks = has_cjk_breaks };
 }
 
 /// Find sparse render-cluster metadata for multibyte clusters and tabs.


### PR DESCRIPTION
Closes https://github.com/anomalyco/opentui/issues/1183.

<img width="873" height="345" alt="image" src="https://github.com/user-attachments/assets/658b4192-83f1-4097-9622-5877c6815229" />

### Follow-Up Fixes And Validation

- Integrated current main (`fbd584b2`), preserving its mixed-grapheme and tab/cursor/history fixes.
- Fixed the demonstrated appended emoji modifier/ZWJ splits, with public Bun/Node regressions and a cached mixed-CJK wrapping control. Source-column units stay unchanged; word navigation does not store or traverse CJK-only line entries.
- Verified: 2,108 native tests, 781 affected Core tests, 4,749 Node 26.4 tests, root build, packed Bun/Node checks, formatting and lint (existing skips retained).
- At `1bd20cbf`: ReleaseFast Linux x64, CPU 2, 12 alternating process pairs. Cached CJK next/previous queries are about 0.065/0.017 us; retained CJK rewrap is about 62.5 us versus 104 us on main. Tradeoffs versus main remain: fragmented navigation and fragmented ASCII measurement about 9-10% overhead; CJK setText/layout/first query about 10% overhead; cold query-before-first-layout about 294 versus 177 us (paired ratio 1.714, 95% CI 1.601-1.835), recurring after invalidation. No blanket performance-parity claim; these are component measurements, not end-user keystroke latencies.
