### PR TITLE
fix(native): keep capability replies in tmux pane

### DIFF
--- a/packages/native/src/terminal.zig
+++ b/packages/native/src/terminal.zig
@@ -296,9 +296,10 @@ pub fn exitAltScreen(self: *Terminal, tty: anytype) !void {
 
 pub fn queryTerminalSend(self: *Terminal, tty: anytype) !void {
     self.checkEnvironmentOverrides();
+    const is_tmux = self.isInTmux();
     self.unicode_wide_locked = self.caps.unicode == .unicode_wide;
-    self.graphics_query_pending = !self.skip_graphics_query;
-    self.sixel_query_pending = !self.skip_graphics_query;
+    self.graphics_query_pending = !self.skip_graphics_query and !is_tmux;
+    self.sixel_query_pending = !self.skip_graphics_query and !is_tmux;
     self.capability_queries_pending = false;
     self.startup_cursor_query_pending = true;
     self.startup_cursor_query_captured = false;
@@ -319,11 +320,11 @@ pub fn queryTerminalSend(self: *Terminal, tty: anytype) !void {
     // Capture the current cursor position before temporary home-position queries.
     try tty.writeAll(ansi.ANSI.cursorPositionRequest);
 
-    if (self.isInTmux()) {
+    if (is_tmux) {
         if (self.is_foot) {
-            try tty.writeAll(ansi.ANSI.capabilityQueriesFootIsBrokenTmux);
+            try tty.writeAll(ansi.ANSI.capabilityQueriesFootIsBroken);
         } else {
-            try tty.writeAll(ansi.ANSI.capabilityQueriesTmux);
+            try tty.writeAll(ansi.ANSI.capabilityQueries);
         }
     } else {
         if (self.is_foot) {
@@ -335,9 +336,10 @@ pub fn queryTerminalSend(self: *Terminal, tty: anytype) !void {
     }
 
     if (!self.skip_graphics_query) {
-        if (self.isInTmux()) {
-            try tty.writeAll(ansi.ANSI.kittyGraphicsQueryTmux);
-            try tty.writeAll(ansi.ANSI.primaryDeviceAttrsTmux);
+        if (is_tmux) {
+            // tmux can answer DA for its virtual terminal. A passthrough Kitty
+            // reply has no pane ownership and may reach a different active pane.
+            try tty.writeAll(ansi.ANSI.primaryDeviceAttrs);
         } else {
             try tty.writeAll(ansi.ANSI.kittyGraphicsQuery);
             try tty.writeAll(ansi.ANSI.primaryDeviceAttrs);
@@ -359,42 +361,16 @@ pub fn queryTerminalSend(self: *Terminal, tty: anytype) !void {
     try tty.writeAll(ansi.ANSI.restoreCursorState);
 }
 
-pub fn sendPendingQueries(self: *Terminal, tty: anytype) !bool {
-    var sent = false;
-    const is_tmux = self.isInTmux();
-
-    // Initial probes were already sent using environment-derived multiplexer
-    // state. Only XTVERSION can justify a differently wrapped retry.
+pub fn sendPendingQueries(self: *Terminal, _: anytype) !bool {
     if (!self.term_info.from_xtversion) return false;
 
-    // Re-send capability queries DCS wrapped if tmux detected via xtversion
-    // Only needed if we got xtversion response indicating tmux
-    if (self.capability_queries_pending) {
-        if (self.term_info.from_xtversion and is_tmux) {
-            try tty.writeAll(ansi.ANSI.capabilityQueriesTmux);
-            sent = true;
-        }
-        // Clear pending flag regardless - non-tmux terminals already received unwrapped queries
-        self.capability_queries_pending = false;
-    }
+    // Startup already queried either the direct terminal or tmux's virtual
+    // terminal. Never retry through passthrough: replies are not pane-scoped.
+    self.capability_queries_pending = false;
+    self.graphics_query_pending = false;
+    self.sixel_query_pending = false;
 
-    if (self.graphics_query_pending and !self.skip_graphics_query) {
-        if (is_tmux) {
-            try tty.writeAll(ansi.ANSI.kittyGraphicsQueryTmux);
-            sent = true;
-        }
-        self.graphics_query_pending = false;
-    }
-
-    if (self.sixel_query_pending and !self.skip_graphics_query) {
-        if (is_tmux) {
-            try tty.writeAll(ansi.ANSI.primaryDeviceAttrsTmux);
-            sent = true;
-        }
-        self.sixel_query_pending = false;
-    }
-
-    return sent;
+    return false;
 }
 
 pub fn enableDetectedFeatures(self: *Terminal, tty: anytype, use_kitty_keyboard: bool) !void {
@@ -1372,6 +1348,12 @@ pub fn processCapabilityResponse(self: *Terminal, response: []const u8) void {
 
     if (!self.caps.hyperlinks and isHyperlinkTerm(response)) {
         self.caps.hyperlinks = true;
+    }
+
+    if (self.isInTmux()) {
+        // Kitty replies passed through tmux are not tied to the requesting pane.
+        self.kitty_graphics_queried = false;
+        self.caps.kitty_graphics = false;
     }
 }
 

--- a/packages/native/src/terminal.zig
+++ b/packages/native/src/terminal.zig
@@ -1091,7 +1091,9 @@ fn parseKittyGraphicsResponse(self: *Terminal, response: []const u8) void {
 }
 
 fn parseSixelDeviceAttributes(self: *Terminal, response: []const u8) void {
-    if (!self.graphics_enabled) return;
+    // Inside tmux, an unwrapped DA response describes tmux's virtual terminal,
+    // not the outer terminal that receives passthrough Sixel output.
+    if (!self.graphics_enabled or self.isInTmux()) return;
     var offset: usize = 0;
     while (std.mem.findPos(u8, response, offset, "\x1b[?")) |start| {
         var end = start + 3;
@@ -1351,9 +1353,13 @@ pub fn processCapabilityResponse(self: *Terminal, response: []const u8) void {
     }
 
     if (self.isInTmux()) {
-        // Kitty replies passed through tmux are not tied to the requesting pane.
+        // Graphics replies inside tmux either have no pane ownership (Kitty
+        // passthrough) or describe tmux itself rather than the passthrough
+        // endpoint (DA/Sixel). Neither can select an outer image protocol.
         self.kitty_graphics_queried = false;
         self.caps.kitty_graphics = false;
+        self.sixel_queried = false;
+        self.caps.sixel = false;
     }
 }
 
@@ -1784,11 +1790,15 @@ pub fn getTerminalName(self: *Terminal) []const u8 {
     return self.term_info.name[0..self.term_info.name_len];
 }
 
-/// Forced Sixel bypasses detection. Refuse it when identity cannot be a
-/// Sixel host. After XTVERSION, a multiplexer is not the host; DA still
-/// wins if the host reported Sixel through it. Apple Terminal has no
-/// XTVERSION, so TERM_PROGRAM is the only identity.
+/// Forced Sixel bypasses detection. Refuse it when the direct endpoint cannot
+/// be a Sixel host. Under tmux the passthrough endpoint is unknown, so the
+/// explicit override is authoritative. Apple Terminal has no XTVERSION, so
+/// TERM_PROGRAM is the only identity.
 pub fn refusesForcedSixel(self: *Terminal) bool {
+    // tmux's outer terminal is intentionally not probed because replies are
+    // not pane-scoped. An explicit override is therefore the authority; tmux's
+    // own DA response must neither authorize nor reject passthrough output.
+    if (self.isInTmux()) return false;
     if (self.caps.sixel) return false;
     if (self.term_info.from_xtversion) {
         if (self.multiplexer != .none) return true;

--- a/packages/native/src/tests/renderer_test.zig
+++ b/packages/native/src/tests/renderer_test.zig
@@ -440,7 +440,7 @@ test "renderer does not send forced Sixel to Apple Terminal" {
     try std.testing.expect(std.mem.find(u8, output, "█") != null);
 }
 
-test "renderer does not send forced Sixel through tmux XTVERSION" {
+test "renderer honors forced Sixel through tmux independently of tmux DA" {
     const pool = gp.initGlobalPool(std.testing.allocator);
     defer gp.deinitGlobalPool();
     defer link.deinitGlobalLinkPool();
@@ -456,13 +456,13 @@ test "renderer does not send forced Sixel through tmux XTVERSION" {
         handles.finishDestroy(token.handle);
     }
     test_renderer.renderer.terminal.processCapabilityResponse("\x1bP>|tmux 3.5a\x1b\\");
+    test_renderer.renderer.terminal.processCapabilityResponse("\x1b[?62;4c");
 
     try std.testing.expect(try test_renderer.renderer.getNextBuffer().drawImage(value, image_handle, 0, 0, 1, 1, 2, 2, 0, 0, 1, 1, .sixel));
     try std.testing.expectEqual(renderer.RenderStatus.rendered, test_renderer.renderer.render(true));
     const output = test_renderer.memory.lastWrite();
-    try std.testing.expect(std.mem.find(u8, output, "\x1bP0;1;0q") == null);
-    try std.testing.expect(std.mem.find(u8, output, "\x1bPtmux;") == null);
-    try std.testing.expect(std.mem.find(u8, output, "█") != null);
+    try std.testing.expect(std.mem.find(u8, output, "\x1bPtmux;") != null);
+    try std.testing.expect(std.mem.find(u8, output, "\x1b\x1bP0;1;0q") != null);
 }
 
 test "renderer does not send forced Sixel to Kitty" {

--- a/packages/native/src/tests/terminal_test.zig
+++ b/packages/native/src/tests/terminal_test.zig
@@ -256,15 +256,42 @@ test "refusesForcedSixel - XTVERSION replaces leftover Apple Terminal env" {
     try testing.expect(!iterm.refusesForcedSixel());
 }
 
-test "refusesForcedSixel - tmux XTVERSION is not a Sixel endpoint" {
+test "tmux DA does not describe the passthrough Sixel endpoint" {
     var env = std.process.Environ.Map.init(testing.allocator);
     defer env.deinit();
     try env.put("TERM_PROGRAM", "Apple_Terminal");
     var term = Terminal.init(.{ .env_map = &env });
     term.processCapabilityResponse("\x1bP>|tmux 3.5a\x1b\\");
-    try testing.expect(term.refusesForcedSixel());
+    try testing.expect(!term.caps.sixel);
+    try testing.expect(!term.refusesForcedSixel());
 
     term.processCapabilityResponse("\x1b[?62;4c");
+    try testing.expect(!term.caps.sixel);
+    try testing.expect(!term.refusesForcedSixel());
+}
+
+test "known tmux ignores its own Sixel DA response" {
+    var env = std.process.Environ.Map.init(testing.allocator);
+    defer env.deinit();
+    try env.put("TMUX", "/tmp/tmux-1000/default,12345,0");
+
+    var supported_tmux = Terminal.init(.{ .env_map = &env });
+    supported_tmux.processCapabilityResponse("\x1b[?1;2;4c");
+    try testing.expect(!supported_tmux.caps.sixel);
+    try testing.expect(!supported_tmux.refusesForcedSixel());
+
+    var unsupported_tmux = Terminal.init(.{ .env_map = &env });
+    unsupported_tmux.processCapabilityResponse("\x1b[?1;2c");
+    try testing.expect(!unsupported_tmux.caps.sixel);
+    try testing.expect(!unsupported_tmux.refusesForcedSixel());
+}
+
+test "late tmux detection clears its Sixel DA response" {
+    var term = Terminal.init(.{});
+    term.processCapabilityResponse("\x1b[?1;2;4c\x1bP>|tmux 3.7b\x1b\\");
+    try testing.expect(term.isInTmux());
+    try testing.expect(!term.caps.sixel);
+    try testing.expect(!term.sixel_queried);
     try testing.expect(!term.refusesForcedSixel());
 }
 

--- a/packages/native/src/tests/terminal_test.zig
+++ b/packages/native/src/tests/terminal_test.zig
@@ -191,6 +191,22 @@ test "graphics identity - multiplexers do not imply outer graphics" {
     try testing.expect(!zellij.caps.sixel);
 }
 
+test "graphics detection - tmux ignores unowned Kitty replies" {
+    var env = std.process.Environ.Map.init(testing.allocator);
+    defer env.deinit();
+    try env.put("TMUX", "/tmp/tmux-1000/default,12345,0");
+
+    var known_tmux = Terminal.init(.{ .env_map = &env });
+    known_tmux.processCapabilityResponse("\x1b_Gi=31337;OK\x1b\\");
+    try testing.expect(!known_tmux.kitty_graphics_queried);
+    try testing.expect(!known_tmux.caps.kitty_graphics);
+
+    var late_tmux = Terminal.init(.{});
+    late_tmux.processCapabilityResponse("\x1b_Gi=31337;OK\x1b\\\x1bP>|tmux 3.5a\x1b\\");
+    try testing.expect(!late_tmux.kitty_graphics_queried);
+    try testing.expect(!late_tmux.caps.kitty_graphics);
+}
+
 test "graphics identity - query response upgrades an unknown terminal" {
     var term = Terminal.init(.{});
     term.processCapabilityResponse("\x1bP>|unknown 1.0\x1b\\");
@@ -824,7 +840,7 @@ test "queryTerminalSend - sends unwrapped queries when not in tmux" {
     try testing.expect(term.sixel_query_pending);
 }
 
-test "queryTerminalSend - sends DCS wrapped queries when in tmux" {
+test "queryTerminalSend - keeps response-generating queries inside tmux" {
     var env = std.process.Environ.Map.init(testing.allocator);
     defer env.deinit();
     try env.put("TMUX", "/tmp/tmux-1000/default,12345,0");
@@ -846,13 +862,19 @@ test "queryTerminalSend - sends DCS wrapped queries when in tmux" {
     try testing.expect(std.mem.find(u8, output, "\x1b[?996n") == null);
     try testing.expect(std.mem.find(u8, output, "\x1bPtmux;\x1b\x1b]10;?") == null);
 
-    // Should contain tmux DCS wrapper start and doubled ESC for queries
-    // wrapForTmux wraps all queries together with one DCS envelope
-    try testing.expect(std.mem.find(u8, output, "\x1bPtmux;\x1b\x1bP+q4d73\x1b\x1b\\") != null);
-    try testing.expect(std.mem.find(u8, output, "\x1b\x1b[?1016$p") != null);
+    // tmux answers these queries through the originating pane's PTY.
+    try testing.expect(std.mem.find(u8, output, "\x1bP+q4d73\x1b\\") != null);
+    try testing.expect(std.mem.find(u8, output, "\x1b[?1016$p") != null);
+    try testing.expect(std.mem.find(u8, output, ansi.ANSI.primaryDeviceAttrs) != null);
 
-    // Should NOT mark capability queries as pending (already sent wrapped)
+    // Passthrough replies have no pane ownership and may reach another pane.
+    try testing.expect(std.mem.find(u8, output, "\x1bPtmux;") == null);
+    try testing.expect(std.mem.find(u8, output, ansi.ANSI.kittyGraphicsQuery) == null);
+
+    // No outer-terminal probes should remain pending.
     try testing.expect(!term.capability_queries_pending);
+    try testing.expect(!term.graphics_query_pending);
+    try testing.expect(!term.sixel_query_pending);
 }
 
 test "queryTerminalSend - sends plain theme queries when TMUX is set" {
@@ -877,11 +899,12 @@ test "queryTerminalSend - sends plain theme queries when TMUX is set" {
     try testing.expect(std.mem.find(u8, output, "\x1b[?996n") == null);
 }
 
-test "sendPendingQueries - sends wrapped queries after tmux detected via xtversion" {
+test "sendPendingQueries - does not retry probes after tmux detected via xtversion" {
     var term = Terminal.init(.{});
     term.multiplexer = .none;
     term.capability_queries_pending = true;
     term.graphics_query_pending = true;
+    term.sixel_query_pending = true;
 
     // Simulate tmux detected via xtversion
     term.processCapabilityResponse("\x1bP>|tmux 3.5a\x1b\\");
@@ -891,20 +914,16 @@ test "sendPendingQueries - sends wrapped queries after tmux detected via xtversi
 
     const did_send = try term.sendPendingQueries(&writer);
 
-    try testing.expect(did_send);
+    try testing.expect(!did_send);
 
     const output = writer.getWritten();
 
-    // Should send DCS wrapped capability queries (wrapForTmux wraps all queries together)
-    try testing.expect(std.mem.find(u8, output, "\x1bPtmux;\x1b\x1bP+q4d73\x1b\x1b\\") != null);
-    try testing.expect(std.mem.find(u8, output, "\x1b\x1b[?1016$p") != null);
-
-    // Should send DCS wrapped graphics query
-    try testing.expect(std.mem.find(u8, output, "\x1bPtmux;\x1b\x1b_G") != null);
+    try testing.expectEqual(@as(usize, 0), output.len);
 
     // Should clear pending flags
     try testing.expect(!term.capability_queries_pending);
     try testing.expect(!term.graphics_query_pending);
+    try testing.expect(!term.sixel_query_pending);
 }
 
 test "sendPendingQueries - clears already-sent direct graphics probes after non-tmux xtversion" {


### PR DESCRIPTION
Closes #1459

## Summary

- Keep response-generating capability probes inside tmux's virtual terminal instead of sending them through DCS passthrough.
- Skip automatic Kitty graphics probing under tmux while retaining tmux-local primary device attributes detection.
- Do not retry startup probes through passthrough after late XTVERSION-based tmux detection.
- Ignore unowned Kitty graphics replies once tmux is known.

## Problem

#415 fixed the framing of the Kitty graphics query from #334, but DCS passthrough only transports output to the outer terminal. A later reply carries no identity for the pane that sent the query.

If a user switches panes before Ghostty replies, tmux may deliver XTGETTCAP, DECRQM, Kitty graphics, or DA response bytes to the newly active shell pane.

OpenTUI already applies the same constraint to theme color queries: DCS passthrough replies are not routed back to the pane that asked.

## Approach

tmux directly handles the capability and DA queries used here and writes replies to the originating pane's PTY. This change sends those queries unwrapped and treats unsupported capabilities conservatively.

The Kitty graphics query is omitted because tmux cannot safely associate its outer-terminal response with the requesting pane. Automatic image protocol selection already falls back under tmux, while an explicit image protocol override remains available.

## Verification

- `bun run test:native`: 2088 passed, 32 skipped
- `bun run build`
- `bun run fmt:check`
- `bun run lint`

The regression tests verify known and late-detected tmux paths, absence of DCS passthrough and Kitty probes, retention of direct tmux-local queries, and rejection of unowned Kitty replies.