### PR TITLE
renderer: preserve native scrollback images

### DIFF
--- a/packages/core/src/tests/renderer.custom-stdout.test.ts
+++ b/packages/core/src/tests/renderer.custom-stdout.test.ts
@@ -367,7 +367,60 @@ test("split-footer Kitty scrollback does not rasterize images to terminal pixel 
   expect(output).toContain("after-image")
 })
 
-test("split-footer queues native image scrollback until the footer is pinned", async () => {
+test.each([
+  { name: "Kitty", response: "\x1b_Gi=31337;OK\x1b\\", placement: "\x1b_Ga=p" },
+  { name: "Sixel", response: "\x1b[?1;4c", placement: "\x1bP0;1;0q" },
+])("split-footer preserves $name images after resize replay resets", async ({ response, placement }) => {
+  const stdin = createTestStdin()
+  const stdout = createCollectingStdout(80, 24)
+  const renderer = await createCliRenderer({
+    stdin,
+    stdout,
+    screenMode: "split-footer",
+    footerHeight: 3,
+    externalOutputMode: "capture-stdout",
+    consoleMode: "disabled",
+  })
+  destroyFns.push(() => renderer.destroy())
+  stdin.emit("data", Buffer.from(response + "\x1b[4;480;800t\x1b[21;1R"))
+  await renderer.idle()
+
+  for (const size of [undefined, { width: 90, height: 28 }, { width: 20, height: 8 }]) {
+    if (size) {
+      renderer.resize(size.width, size.height)
+      stdin.emit("data", Buffer.from(`\x1b[4;${size.height * 20};${size.width * 10}t`))
+      renderer.resetSplitFooterForReplay({ clearSavedLines: true })
+      await renderer.idle()
+    }
+    await flushWritable(stdout)
+    stdout.clearWrites()
+
+    const surface = renderer.createScrollbackSurface({ startOnNewLine: true })
+    try {
+      const image = new ImageRenderable(surface.renderContext, {
+        source: PNG_1X1,
+        width: 2,
+        height: 5,
+        fit: "fill",
+      })
+      surface.root.add(image)
+      await image.loadPromise
+      surface.render()
+      surface.commitRows(0, surface.height, { trailingNewline: true })
+    } finally {
+      surface.destroy()
+    }
+    await renderer.idle()
+    await flushWritable(stdout)
+
+    const output = stdout.getWrittenBytes().toString("utf8")
+    expect(output).toContain(placement)
+    expect(output).toContain("\x1b[4A\r")
+    expect(output).not.toContain("\u2588")
+  }
+})
+
+test("split-footer queues native image scrollback until the startup cursor reply", async () => {
   const stdin = createTestStdin()
   const stdout = createCollectingStdout(8, 6)
   const renderer = await createCliRenderer({

--- a/packages/native/src/renderer.zig
+++ b/packages/native/src/renderer.zig
@@ -1277,15 +1277,15 @@ pub const CliRenderer = struct {
         row_columns: u32,
         start_on_new_line: bool,
         previous_output_column: u32,
-        previous_output_offset: u32,
         pinned_render_offset: u32,
     ) bool {
-        if (pinned_render_offset == 0 or previous_output_offset != pinned_render_offset or
-            (!start_on_new_line and previous_output_column != 0)) return false;
+        if (pinned_render_offset == 0 or (!start_on_new_line and previous_output_column != 0)) return false;
+        // Images are placed after their last row is written. Even while the footer
+        // is settling, the rectangle remains addressable if it fits the upper pane.
         for (placements) |placement| {
             if (placement.x < 0 or placement.y < 0 or
                 @as(u64, @intCast(placement.x)) + placement.width > row_columns or
-                placement.height > previous_output_offset) return false;
+                placement.height > pinned_render_offset) return false;
         }
         return true;
     }
@@ -1311,7 +1311,6 @@ pub const CliRenderer = struct {
         row_columns: u32,
         start_on_new_line: bool,
         previous_output_column: u32,
-        previous_output_offset: u32,
         pinned_render_offset: u32,
     ) !SnapshotImageState {
         const placements = snapshot.image_placements.items;
@@ -1335,7 +1334,6 @@ pub const CliRenderer = struct {
                 row_columns,
                 start_on_new_line,
                 previous_output_column,
-                previous_output_offset,
                 pinned_render_offset,
             )) {
                 try snapshot.materializeImageFallbacks();
@@ -1358,7 +1356,6 @@ pub const CliRenderer = struct {
             row_columns,
             start_on_new_line,
             previous_output_column,
-            previous_output_offset,
             pinned_render_offset,
         )) {
             try snapshot.materializeImageFallbacks();
@@ -1651,7 +1648,6 @@ pub const CliRenderer = struct {
             normalized_row_columns,
             start_on_new_line,
             previousOutputColumn,
-            previousOutputOffset,
             pinned_render_offset,
         );
         const starts_mid_line = previousOutputColumn > 0 and start_on_new_line;

--- a/packages/native/src/tests/renderer_test.zig
+++ b/packages/native/src/tests/renderer_test.zig
@@ -2650,6 +2650,58 @@ test "renderer - split scrollback uses native Kitty when Kitty is selected" {
     try std.testing.expect(std.mem.find(u8, output, "48;2;1;2;3") == null);
 }
 
+test "renderer - split scrollback images remain addressable before and across pinning" {
+    const pool = gp.initGlobalPool(std.testing.allocator);
+    defer gp.deinitGlobalPool();
+    var local_link_pool = link.LinkPool.init(std.testing.allocator);
+    defer local_link_pool.deinit();
+    const value = try image.createFromRgba(std.testing.allocator, &[_]u8{ 255, 0, 0, 255 }, 1, 1, 4);
+    const image_handle = try handles.insert(.image, @ptrCast(value));
+    defer {
+        const token = handles.beginDestroy(image_handle, .image, image.Image).?;
+        token.ptr.deinit();
+        handles.finishDestroy(token.handle);
+    }
+
+    for ([_]bool{ false, true }) |sixel| {
+        for ([_]u32{ 0, 2, 5, 6 }) |seed_rows| {
+            for ([_]u32{ 1, 4, 6, 7 }) |height| {
+                var test_renderer = try TestRenderer.create(std.testing.allocator, 4, 3, pool);
+                defer test_renderer.deinit();
+                test_renderer.renderer.terminal.caps.kitty_graphics = !sixel;
+                test_renderer.renderer.terminal.caps.sixel = sixel;
+                const snapshot = try OptimizedBuffer.init(std.testing.allocator, 4, height + 2, .{ .pool = pool, .link_pool = &local_link_pool });
+                defer snapshot.deinit();
+                try snapshot.drawText("top", 0, 0, .{ 255, 255, 255, 255 }, null, 0);
+                try std.testing.expect(try snapshot.drawImage(value, image_handle, 0, 1, 2, height, 4, height * 2, 0, 0, 1, 1, .auto));
+                try snapshot.drawText("end", 0, @intCast(height + 1), .{ 255, 255, 255, 255 }, null, 0);
+                _ = test_renderer.renderer.resetSplitScrollback(seed_rows, 6);
+
+                const result = test_renderer.renderer.commitSplitFooterSnapshotBatched(snapshot, 4, true, true, 6, false, true, true);
+                try std.testing.expectEqual(renderer.RenderStatus.rendered, result.status);
+                const output = test_renderer.memory.lastWrite();
+                const placement = std.mem.find(u8, output, if (sixel) "\x1bP0;1;0q" else "\x1b_Ga=p");
+                try std.testing.expectEqual(height <= 6, placement != null);
+                try std.testing.expectEqual(height > 6, std.mem.find(u8, output, "\xe2\x96\x88") != null);
+                if (placement) |index| {
+                    try std.testing.expect(std.mem.find(u8, output, "top").? < index);
+                    try std.testing.expect(index < std.mem.find(u8, output, "end").?);
+                    var terminal: ghostty_vt.vt.Terminal = try .init(std.testing.io, std.testing.allocator, .{
+                        .cols = 4,
+                        .rows = 9,
+                    });
+                    defer terminal.deinit(std.testing.allocator);
+                    var stream = terminal.vtStream();
+                    defer stream.deinit();
+                    stream.nextSlice(output[0..index]);
+                    try std.testing.expectEqual(@as(u16, 0), terminal.screens.active.cursor.x);
+                    try std.testing.expectEqual(@min(@max(seed_rows, 1) + height, 6) - height, terminal.screens.active.cursor.y);
+                }
+            }
+        }
+    }
+}
+
 test "renderer - failed Kitty scrollback preparation does not publish the batch" {
     const pool = gp.initGlobalPool(std.testing.allocator);
     defer gp.deinitGlobalPool();

--- a/packages/web/src/content/docs/components/image.mdx
+++ b/packages/web/src/content/docs/components/image.mdx
@@ -111,7 +111,7 @@ Kitty preserves image alpha, Sixel treats alpha below 128 as transparent, and bl
 
 Use `OPENTUI_IMAGE_PROTOCOL=auto|kitty|sixel|blocks` to set the global default. `OPENTUI_GRAPHICS=false` disables Kitty and Sixel detection. See [Environment variables](/docs/reference/env-vars).
 
-Split-footer scrollback snapshots use the same protocol resolution as live images. They use Kitty placement, Sixel with detected pixel geometry, or Unicode quadrant blocks. Snapshots with mixed effective protocols, overlapping images, or covered Sixel cells use blocks. Native scrollback placement starts when the footer is pinned and the image rectangle is addressable. Await `loadPromise` before rendering an image into a `ScrollbackSurface`. See [Writing to scrollback](/docs/core-concepts/renderer#writing-to-scrollback).
+Split-footer scrollback snapshots use the same protocol resolution as live images. They use Kitty placement, Sixel with detected pixel geometry, or Unicode quadrant blocks. Snapshots with mixed effective protocols, overlapping images, or covered Sixel cells use blocks. Native scrollback images can render before the footer is pinned. Each image must fit within the output width and the height available above the pinned footer, and its snapshot must start at the beginning of a line. Await `loadPromise` before rendering an image into a `ScrollbackSurface`. See [Writing to scrollback](/docs/core-concepts/renderer#writing-to-scrollback).
 
 `resolveImageRenderProtocol(requested, capabilities, hasResolution)` exposes the same protocol-resolution policy for code that needs it without constructing a renderable.
 


### PR DESCRIPTION
Requiring a pinned footer forces scrollback images to fall back to
blocks during startup and after resize replay resets. Allow Kitty and
Sixel images before pinning when they fit above the pinned footer to
preserve image quality while the footer settles.
