### PR TITLE
ci: check stacked pull requests

### DIFF
--- a/.github/workflows/stacked-pr.yml
+++ b/.github/workflows/stacked-pr.yml
@@ -1,0 +1,63 @@
+name: Stacked PR Check
+
+on:
+  pull_request:
+    branches-ignore: [main]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  check:
+    name: Stacked PR Check
+    runs-on: blacksmith-8vcpu-ubuntu-2404
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Find changed packages
+        id: changes
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: |
+          git diff --name-only "$BASE_SHA"...HEAD \
+            | sed -n 's#^\(packages/[^/]*\)/.*#\1#p' \
+            | sort -u > "$RUNNER_TEMP/changed-packages"
+          if grep -qx packages/native "$RUNNER_TEMP/changed-packages"; then
+            echo "native=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.14
+
+      - name: Setup Zig
+        if: steps.changes.outputs.native == 'true'
+        uses: mlugg/setup-zig@v2
+        with:
+          version: 0.16.0
+          use-cache: false
+
+      - name: Install dependencies
+        run: bun install
+
+      - name: Check formatting and lint
+        run: |
+          bun run fmt:check
+          bun run lint:ci
+
+      - name: Test changed packages
+        run: |
+          while IFS= read -r package; do
+            [ -f "$package/package.json" ] || continue
+            bun run --cwd "$package" --if-present typecheck
+            bun run --cwd "$package" --if-present test
+          done < "$RUNNER_TEMP/changed-packages"


### PR DESCRIPTION
Run Linux format, lint, typecheck, and affected-package tests for PRs targeting non-main branches. Main-targeted PRs continue using only the existing full CI.