### PR TITLE
ci: skip symbols in dependent package builds

### DIFF
--- a/.github/actions/setup-native-symbol-tools/action.yml
+++ b/.github/actions/setup-native-symbol-tools/action.yml
@@ -3,9 +3,20 @@ description: Make cross-target LLVM tools available to native package builds
 runs:
   using: composite
   steps:
-    - if: runner.os == 'macOS'
-      shell: bash
+    - shell: bash
       run: |
         set -euo pipefail
-        brew list llvm >/dev/null 2>&1 || brew install llvm
-        echo "LLVM_BIN=$(brew --prefix llvm)/bin" >> "$GITHUB_ENV"
+        case "$RUNNER_OS" in
+          macOS)
+            brew list llvm >/dev/null 2>&1 || brew install llvm
+            echo "LLVM_BIN=$(brew --prefix llvm)/bin" >> "$GITHUB_ENV"
+            ;;
+          Windows)
+            if [ ! -x '/c/Program Files/LLVM/bin/llvm-pdbutil.exe' ]; then
+              choco install llvm -y --no-progress
+            fi
+            test -x '/c/Program Files/LLVM/bin/llvm-readobj.exe'
+            test -x '/c/Program Files/LLVM/bin/llvm-pdbutil.exe'
+            echo "LLVM_BIN=C:/Program Files/LLVM/bin" >> "$GITHUB_ENV"
+            ;;
+        esac

--- a/.github/actions/setup-native-symbol-tools/action.yml
+++ b/.github/actions/setup-native-symbol-tools/action.yml
@@ -3,20 +3,9 @@ description: Make cross-target LLVM tools available to native package builds
 runs:
   using: composite
   steps:
-    - shell: bash
+    - if: runner.os == 'macOS'
+      shell: bash
       run: |
         set -euo pipefail
-        case "$RUNNER_OS" in
-          macOS)
-            brew list llvm >/dev/null 2>&1 || brew install llvm
-            echo "LLVM_BIN=$(brew --prefix llvm)/bin" >> "$GITHUB_ENV"
-            ;;
-          Windows)
-            if [ ! -x '/c/Program Files/LLVM/bin/llvm-pdbutil.exe' ]; then
-              choco install llvm -y --no-progress
-            fi
-            test -x '/c/Program Files/LLVM/bin/llvm-readobj.exe'
-            test -x '/c/Program Files/LLVM/bin/llvm-pdbutil.exe'
-            echo "LLVM_BIN=C:/Program Files/LLVM/bin" >> "$GITHUB_ENV"
-            ;;
-        esac
+        brew list llvm >/dev/null 2>&1 || brew install llvm
+        echo "LLVM_BIN=$(brew --prefix llvm)/bin" >> "$GITHUB_ENV"

--- a/.github/workflows/build-keymap.yml
+++ b/.github/workflows/build-keymap.yml
@@ -54,13 +54,11 @@ jobs:
       - name: Install dependencies
         run: bun install
 
-      - name: Setup native symbol tools
-        uses: ./.github/actions/setup-native-symbol-tools
-
       - name: Build core
         run: |
           cd packages/core
-          bun run build
+          bun run build:native --skip-symbols
+          bun run build:lib
 
       - name: Build
         run: |

--- a/.github/workflows/build-qrcode.yml
+++ b/.github/workflows/build-qrcode.yml
@@ -52,13 +52,11 @@ jobs:
       - name: Install dependencies
         run: bun install
 
-      - name: Setup native symbol tools
-        uses: ./.github/actions/setup-native-symbol-tools
-
       - name: Build core
         run: |
           cd packages/core
-          bun run build
+          bun run build:native --skip-symbols
+          bun run build:lib
 
       - name: Build
         run: |

--- a/.github/workflows/build-react.yml
+++ b/.github/workflows/build-react.yml
@@ -53,13 +53,11 @@ jobs:
       - name: Install dependencies
         run: bun install
 
-      - name: Setup native symbol tools
-        uses: ./.github/actions/setup-native-symbol-tools
-
       - name: Build core
         run: |
           cd packages/core
-          bun run build
+          bun run build:native --skip-symbols
+          bun run build:lib
 
       - name: Build
         run: |

--- a/.github/workflows/build-solid.yml
+++ b/.github/workflows/build-solid.yml
@@ -54,12 +54,11 @@ jobs:
       - name: Install dependencies
         run: bun install
 
-      - name: Setup native symbol tools
-        uses: ./.github/actions/setup-native-symbol-tools
-
       - name: Build core
         working-directory: packages/core
-        run: bun run build
+        run: |
+          bun run build:native --skip-symbols
+          bun run build:lib
 
       - name: Build
         working-directory: packages/solid

--- a/.github/workflows/build-ssh.yml
+++ b/.github/workflows/build-ssh.yml
@@ -49,13 +49,11 @@ jobs:
       - name: Install dependencies
         run: bun install
 
-      - name: Setup native symbol tools
-        uses: ./.github/actions/setup-native-symbol-tools
-
       - name: Build core
         run: |
           cd packages/core
-          bun run build
+          bun run build:native --skip-symbols
+          bun run build:lib
 
       - name: Build framework declarations
         run: |

--- a/packages/core/scripts/build.ts
+++ b/packages/core/scripts/build.ts
@@ -54,6 +54,7 @@ const isDev = args.includes("--dev")
 const buildAll = args.includes("--all") // Build for all platforms
 const gpaSafeStats = args.includes("--gpa-safe-stats")
 const skipZig = args.includes("--skip-zig")
+const skipSymbols = args.includes("--skip-symbols")
 
 const getHostVariant = (): Variant => {
   const hostVariant = variants.find((variant) => variant.platform === process.platform && variant.arch === process.arch)
@@ -225,7 +226,7 @@ if (buildNative) {
       continue
     }
 
-    if (!isDev && libraryFileName) {
+    if (!isDev && !skipSymbols && libraryFileName) {
       separateNativeSymbols({
         binary: join(nativeDir, libraryFileName),
         symbolsDir: join(nativeRoot, "symbols", `${platform}-${arch}${abi ? `-${abi}` : ""}`),


### PR DESCRIPTION
It removes the flaky Chocolatey/LLVM installation from five package-test workflows, so a network timeout no longer blocks those tests before they even build.

It also avoids repeated symbol processing in those jobs. Builds remain `ReleaseFast`, and release symbol publishing is unchanged.

Releases still publish all eight native symbol archives, including Windows. The symbol generation, verification, and release-upload steps are unchanged.