### PR TITLE
feat(core): add native PCM stream playback

### DIFF
--- a/packages/core/scripts/test-node.ts
+++ b/packages/core/scripts/test-node.ts
@@ -145,6 +145,7 @@ const emittedAllowlist = [
   ".node-test/src/tests/renderable.snapshot.test.js",
   ".node-test/src/tests/allocator-stats.test.js",
   ".node-test/src/tests/audio-stream.test.js",
+  ".node-test/src/tests/audio-pcm-stream.test.js",
   ".node-test/src/tests/clipboard-native-lifecycle.test.js",
   ".node-test/src/tests/audio.test.js",
   ".node-test/src/tests/image-renderable.test.js",

--- a/packages/core/src/audio.ts
+++ b/packages/core/src/audio.ts
@@ -185,6 +185,9 @@ export type AudioStreamAction =
   | "setVolume"
   | "setPan"
   | "setGroup"
+  | "pause"
+  | "resume"
+  | "clear"
 
 export interface AudioStreamErrorContext {
   action: AudioStreamAction
@@ -2727,6 +2730,348 @@ export class AudioRecorder extends EventEmitter<AudioRecorderEvents> {
   }
 }
 
+export interface AudioPcmStreamOptions {
+  /** Interleaved float32 input rate in Hz (8,000–192,000). */
+  sampleRate: number
+  channels: 1 | 2
+  volume?: number
+  pan?: number
+  groupId?: number
+  buffer?: AudioStreamBufferOptions
+  signal?: AbortSignal
+}
+
+export type AudioPcmStreamState = "buffering" | "playing" | "paused" | "ended" | "errored" | "disposed"
+
+export interface AudioPcmStreamStats {
+  state: AudioPcmStreamState
+  /** Mixer rate; all output frame counts use this rate. */
+  sampleRate: number
+  channels: number
+  bufferedFrames: number
+  capacityFrames: number
+  bufferedDurationMs: number
+  /** Accepted input frames at the stream's input sample rate. */
+  framesWritten: bigint
+  framesConverted: bigint
+  framesPlayed: bigint
+  underruns: number
+}
+
+export interface AudioPcmStreamEvents {
+  ended: []
+  error: [error: AudioStreamError, context: AudioStreamErrorContext]
+  disposed: []
+}
+
+let createAudioPcmStream: (
+  lib: RenderLib,
+  engine: AudioEngineHandle,
+  options: AudioPcmStreamOptions,
+  removeFromOwner: () => void,
+) => AudioPcmStream
+
+/** A bounded PCM playback writer. Await each write before reusing its backing memory. */
+export class AudioPcmStream extends EventEmitter<AudioPcmStreamEvents> {
+  readonly closed: Promise<void>
+  readonly sampleRate: number
+  readonly channels: 1 | 2
+  private streamId: number | null
+  private snapshot: NativeAudioStreamStats
+  private terminalState: AudioPcmStreamState | null = null
+  private terminalError: AudioStreamError | null = null
+  private readonly controller = new AbortController()
+  private writeController: AbortController | null = null
+  private pendingWrite: Promise<void> | null = null
+  private ending: Promise<void> | null = null
+  private closedResolve!: () => void
+  private readonly onAbort = () => this.dispose()
+  private readonly signal?: AbortSignal
+
+  static {
+    createAudioPcmStream = (lib, engine, options, removeFromOwner) =>
+      new AudioPcmStream(lib, engine, options, removeFromOwner)
+  }
+
+  private constructor(
+    private readonly lib: RenderLib,
+    private readonly engine: AudioEngineHandle,
+    options: AudioPcmStreamOptions,
+    private readonly removeFromOwner: () => void,
+  ) {
+    super()
+    if (!Number.isInteger(options.sampleRate) || options.sampleRate < 8000 || options.sampleRate > 192000) {
+      throw new RangeError("sampleRate must be an integer from 8000 to 192000 Hz")
+    }
+    if (options.channels !== 1 && options.channels !== 2) throw new RangeError("channels must be 1 or 2")
+    const buffer = resolveAudioStreamOptions({
+      ...options,
+      buffer: { capacityMs: 500, startupMs: 20, resumeMs: 20, ...options.buffer },
+    })
+    if (!isU32(buffer.groupId) || !Number.isFinite(buffer.volume) || !Number.isFinite(buffer.pan)) {
+      throw new TypeError("Invalid PCM stream volume, pan, or groupId")
+    }
+    this.signal = options.signal
+    if (this.signal?.aborted) throw createAbortError()
+    this.sampleRate = options.sampleRate
+    this.channels = options.channels
+    const created = lib.audioCreatePcmStream(engine, {
+      ...buffer,
+      sampleRate: this.sampleRate,
+      channels: this.channels,
+    })
+    if (created.status !== 0 || created.streamId == null) {
+      throw new AudioStreamError(`PCM stream create failed: ${created.status}`, {
+        action: "create",
+        status: created.status,
+      })
+    }
+    this.streamId = created.streamId
+    this.closed = new Promise((resolve) => (this.closedResolve = resolve))
+    // Creation has completed conversion setup; no source or startup data is needed for readiness.
+    this.snapshot = {
+      bytesReceived: 0n,
+      framesDecoded: 0n,
+      framesPlayed: 0n,
+      state: StreamState.Buffering,
+      sampleRate: 0,
+      channels: 2,
+      bufferedFrames: 0,
+      capacityFrames: 0,
+      underruns: 0,
+      errorCode: 0,
+      readyGeneration: 1,
+    }
+    try {
+      this.refresh()
+      this.signal?.addEventListener("abort", this.onAbort, { once: true })
+    } catch (error) {
+      this.dispose()
+      throw error
+    }
+  }
+
+  get state(): AudioPcmStreamState {
+    return (
+      this.terminalState ??
+      (this.snapshot.state === StreamState.Paused
+        ? "paused"
+        : this.snapshot.state === StreamState.Playing
+          ? "playing"
+          : "buffering")
+    )
+  }
+
+  get error(): AudioStreamError | null {
+    return this.terminalError
+  }
+
+  getStats(): AudioPcmStreamStats {
+    if (this.streamId != null && !this.controller.signal.aborted) {
+      try {
+        this.refresh()
+      } catch (cause) {
+        throw this.fail("stats", cause)
+      }
+    }
+    const stats = this.snapshot
+    return {
+      state: this.state,
+      sampleRate: stats.sampleRate,
+      channels: stats.channels,
+      bufferedFrames: stats.bufferedFrames,
+      capacityFrames: stats.capacityFrames,
+      bufferedDurationMs: (stats.bufferedFrames * 1000) / stats.sampleRate,
+      framesWritten: stats.bytesReceived / BigInt(4 * this.channels),
+      framesConverted: stats.framesDecoded,
+      framesPlayed: stats.framesPlayed,
+      underruns: stats.underruns,
+    }
+  }
+
+  write(frames: Float32Array): Promise<void> {
+    try {
+      this.requireWritable()
+      if (this.pendingWrite != null) throw new Error("Await the previous PCM write before writing again")
+      if (!ArrayBuffer.isView(frames) || Object.prototype.toString.call(frames) !== "[object Float32Array]") {
+        throw new TypeError("PCM chunks must be Float32Array instances")
+      }
+      if (Object.prototype.toString.call(frames.buffer) === "[object SharedArrayBuffer]") {
+        throw new TypeError("PCM chunks must have non-shared backing memory")
+      }
+      if (frames.length % this.channels !== 0) throw new RangeError("PCM chunks must contain whole interleaved frames")
+    } catch (error) {
+      return Promise.reject(error)
+    }
+    const controller = new AbortController()
+    this.writeController = controller
+    const promise = this.writeChunk(frames, controller.signal)
+    this.pendingWrite = promise
+    const release = () => {
+      if (this.pendingWrite === promise) {
+        this.pendingWrite = null
+        this.writeController = null
+      }
+    }
+    void promise.then(release, release)
+    return promise
+  }
+
+  private async writeChunk(frames: Float32Array, signal: AbortSignal): Promise<void> {
+    try {
+      const length = frames.length
+      let offset = 0
+      let batches = 0
+      while (offset < length) {
+        if (signal.aborted || this.controller.signal.aborted) throw createAbortError()
+        const batch = frames.subarray(offset, Math.min(length, offset + 2048 * this.channels))
+        if (batch.length === 0) throw new TypeError("PCM backing memory was detached during write")
+        const accepted = this.lib.audioWritePcmStream(this.engine, this.streamId!, batch)
+        this.checkStatus("write", accepted)
+        offset += accepted * this.channels
+        // Bound work even for very large chunks and an actively draining output device.
+        if (accepted === 0 || ++batches % 32 === 0) {
+          await waitForDelay(accepted === 0 ? STREAM_POLL_INTERVAL_MS : 0, signal)
+        }
+      }
+    } catch (cause) {
+      if (signal.aborted || this.controller.signal.aborted) throw this.terminalError ?? createAbortError()
+      throw this.fail("write", cause)
+    }
+  }
+
+  /** Seal input, flush conversion history, drain playback, and release native storage. */
+  end(): Promise<void> {
+    if (this.ending != null) return this.ending
+    if (this.terminalState === "ended") return Promise.resolve()
+    if (this.controller.signal.aborted) return Promise.reject(this.terminalError ?? createAbortError())
+    this.ending = this.drain()
+    return this.ending
+  }
+
+  private async drain(): Promise<void> {
+    try {
+      await this.pendingWrite
+      while (!this.controller.signal.aborted) {
+        const status = this.lib.audioEndPcmStream(this.engine, this.streamId!)
+        this.checkStatus("end", status)
+        this.refresh()
+        if (status === 0 && this.snapshot.state === StreamState.Ended) {
+          this.finish("ended")
+          return
+        }
+        await waitForDelay(STREAM_POLL_INTERVAL_MS, this.controller.signal)
+      }
+      throw this.terminalError ?? createAbortError()
+    } catch (cause) {
+      if (this.controller.signal.aborted) throw this.terminalError ?? createAbortError()
+      throw this.fail("end", cause)
+    }
+  }
+
+  pause(): void {
+    this.control("pause", (id) => this.lib.audioSetPcmStreamPaused(this.engine, id, true))
+  }
+
+  resume(): void {
+    this.control("resume", (id) => this.lib.audioSetPcmStreamPaused(this.engine, id, false))
+  }
+
+  /** Discard queued audio and abort an in-flight write. The stream remains writable. */
+  clear(): void {
+    this.requireWritable()
+    this.control("clear", (id) => this.lib.audioClearPcmStream(this.engine, id))
+    this.writeController?.abort()
+    this.writeController = null
+    this.pendingWrite = null
+  }
+
+  setVolume(volume: number): void {
+    if (!Number.isFinite(volume)) throw new TypeError("volume must be finite")
+    this.control("setVolume", (id) => this.lib.audioSetStreamVolume(this.engine, id, volume))
+  }
+
+  setPan(pan: number): void {
+    if (!Number.isFinite(pan)) throw new TypeError("pan must be finite")
+    this.control("setPan", (id) => this.lib.audioSetStreamPan(this.engine, id, pan))
+  }
+
+  setGroup(groupId: number): void {
+    if (!isU32(groupId)) throw new TypeError("Invalid PCM stream groupId")
+    this.control("setGroup", (id) => this.lib.audioSetStreamGroup(this.engine, id, groupId))
+  }
+
+  dispose(): void {
+    if (this.streamId == null) return
+    this.finish("disposed")
+  }
+
+  private requireWritable(): void {
+    if (this.controller.signal.aborted) throw this.terminalError ?? createAbortError()
+    if (this.ending != null) throw new Error("PCM stream input has ended")
+  }
+
+  private checkStatus(action: AudioStreamAction, status: number): void {
+    if (status < 0) throw new AudioStreamError(`PCM stream ${action} failed: ${status}`, { action, status })
+  }
+
+  private refresh(): void {
+    const snapshot = this.lib.audioGetStreamStats(this.engine, this.streamId!)
+    if (snapshot == null) throw new AudioStreamError("PCM stream stats unavailable", { action: "stats" })
+    this.snapshot = snapshot
+    if (snapshot.state === StreamState.Failed) {
+      throw new AudioStreamError("PCM stream failed", { action: "stats", errorCode: snapshot.errorCode })
+    }
+  }
+
+  private control(action: AudioStreamAction, call: (id: number) => number): void {
+    if (this.controller.signal.aborted) throw this.terminalError ?? createAbortError()
+    try {
+      this.checkStatus(action, call(this.streamId!))
+      this.refresh()
+    } catch (cause) {
+      throw this.fail(action, cause)
+    }
+  }
+
+  private fail(action: AudioStreamAction, cause: unknown): AudioStreamError {
+    const error =
+      cause instanceof AudioStreamError ? cause : new AudioStreamError(`PCM stream ${action} failed`, { action }, cause)
+    this.terminalError = error
+    this.finish("errored")
+    return error
+  }
+
+  private finish(state: "ended" | "errored" | "disposed"): void {
+    this.controller.abort()
+    this.writeController?.abort()
+    const reason =
+      state === "ended"
+        ? CloseReason.PreserveNativeTerminal
+        : state === "errored"
+          ? CloseReason.TransportError
+          : CloseReason.Disposed
+    if (this.streamId != null) {
+      const result = this.lib.audioCloseStream(this.engine, this.streamId, reason)
+      this.checkStatus("destroy", result.status)
+      if (result.stats != null) this.snapshot = result.stats
+      this.streamId = null
+    }
+    this.terminalState = state
+    this.signal?.removeEventListener("abort", this.onAbort)
+    this.removeFromOwner()
+    queueMicrotask(() => {
+      try {
+        if (state === "errored") {
+          if (this.listenerCount("error") > 0) this.emit("error", this.terminalError!, this.terminalError!.context)
+        } else this.emit(state)
+      } finally {
+        this.closedResolve()
+      }
+    })
+  }
+}
+
 export class Audio extends EventEmitter<AudioEvents> {
   static create(options: AudioSetupOptions = {}): Audio {
     let lib: RenderLib
@@ -2951,6 +3296,15 @@ export class Audio extends EventEmitter<AudioEvents> {
     }
 
     return result.voiceId
+  }
+
+  createPcmStream(options: AudioPcmStreamOptions): AudioPcmStream {
+    const engine = this.engine
+    if (!engine || this.disposing) throw new Error("Audio engine unavailable during PCM stream creation")
+    let stream: AudioPcmStream
+    stream = createAudioPcmStream(this.lib, engine, options, () => this.streams.delete(stream))
+    this.streams.add(stream)
+    return stream
   }
 
   async playStream<M = AudioStreamMetadata>(

--- a/packages/core/src/tests/audio-pcm-stream.test.ts
+++ b/packages/core/src/tests/audio-pcm-stream.test.ts
@@ -1,0 +1,319 @@
+import { afterEach, expect, test } from "bun:test"
+import { runInNewContext } from "node:vm"
+import { getEventListeners } from "node:events"
+import { Audio, AudioPcmStream, AudioStreamError, type AudioPcmStreamOptions } from "../index.js"
+import { resolveRenderLib } from "../zig.js"
+
+const audios: Audio[] = []
+const options: AudioPcmStreamOptions = {
+  sampleRate: 48000,
+  channels: 2,
+  buffer: { capacityMs: 10, startupMs: 2, resumeMs: 2 },
+}
+
+function createAudio(sampleRate = 48000): Audio {
+  const audio = Audio.create({ autoStart: false, sampleRate })
+  audios.push(audio)
+  audio.on("error", () => {})
+  expect(audio.startMixer()).toBe(true)
+  return audio
+}
+
+async function drive(audio: Audio, operation: Promise<void>): Promise<Float32Array> {
+  let done = false
+  let failure: unknown
+  void operation.then(
+    () => {
+      done = true
+    },
+    (error) => {
+      done = true
+      failure = error
+    },
+  )
+  const output: number[] = []
+  for (let i = 0; i < 2000 && !done; i++) {
+    await new Promise((resolve) => setTimeout(resolve, 0))
+    if (!done) output.push(...audio.mixFrames(128)!)
+  }
+  expect(done).toBe(true)
+  if (failure) throw failure
+  return new Float32Array(output)
+}
+
+afterEach(() => {
+  for (const audio of audios.splice(0)) audio.dispose()
+})
+
+test("PCM writer is ready without input and copies offset views before write resolves", async () => {
+  const audio = createAudio()
+  const stream = audio.createPcmStream(options)
+  expect(stream).toBeInstanceOf(AudioPcmStream)
+  expect(stream.state).toBe("buffering")
+  const owner = new Float32Array(964).fill(0.9)
+  const frames = owner.subarray(2, 962)
+  for (let i = 0; i < frames.length; i += 2) {
+    frames[i] = 0.25
+    frames[i + 1] = -0.5
+  }
+  await stream.write(frames)
+  owner.fill(0)
+  expect(audio.enableTap(256)).toBe(true)
+  const output = audio.mixFrames(128)!
+  expect(output[2]).toBeCloseTo(0.25)
+  expect(output[3]).toBeCloseTo(-0.5)
+  expect(audio.readTapFrames(128)!.frames).toEqual(output)
+  expect(stream.getStats().framesWritten).toBe(480n)
+  await drive(audio, stream.end())
+  await stream.closed
+  expect(stream.state).toBe("ended")
+  expect(stream.getStats().framesPlayed).toBe(480n)
+  expect(audio.getStats()!.voicesActive).toBe(0)
+})
+
+test("PCM writer backpressures without dropping frames and rejects concurrent writes", async () => {
+  const audio = createAudio()
+  const stream = audio.createPcmStream(options)
+  let completed = false
+  const write = stream.write(new Float32Array(2400).fill(0.125)).then(() => {
+    completed = true
+  })
+  await expect(stream.write(new Float32Array(2))).rejects.toThrow("Await the previous")
+  expect(completed).toBe(false)
+  expect(stream.getStats().bufferedFrames).toBe(480)
+  await drive(audio, write)
+  await drive(audio, stream.end())
+  expect(stream.getStats().framesWritten).toBe(1200n)
+  expect(stream.getStats().framesPlayed).toBe(1200n)
+})
+
+test("PCM pause retains the queue; clear aborts pending input and resets conversion history", async () => {
+  const audio = createAudio()
+  const stream = audio.createPcmStream({ ...options, sampleRate: 44100, channels: 1 })
+  stream.pause()
+  const oldWrite = stream.write(new Float32Array(10000).fill(0.5))
+  const rejected = oldWrite.catch((error: Error) => error)
+  expect(stream.getStats().state).toBe("paused")
+  expect(audio.mixFrames(128)!.every((sample) => sample === 0)).toBe(true)
+  expect(stream.getStats().framesPlayed).toBe(0n)
+  stream.clear()
+  expect(stream.getStats().bufferedFrames).toBe(0)
+  await stream.write(new Float32Array(100))
+  expect(((await rejected) as Error).name).toBe("AbortError")
+  stream.resume()
+  const output = await drive(audio, stream.end())
+  expect(output.every((sample) => sample === 0)).toBe(true)
+})
+
+test("PCM underruns emit silence and wait for the resume threshold", async () => {
+  const audio = createAudio()
+  const stream = audio.createPcmStream(options)
+  await stream.write(new Float32Array(192).fill(0.25))
+  expect(audio.mixFrames(128)!.some((sample) => sample !== 0)).toBe(true)
+  expect(stream.getStats().underruns).toBe(1)
+  await stream.write(new Float32Array(2).fill(0.5))
+  expect(audio.mixFrames(128)!.every((sample) => sample === 0)).toBe(true)
+  expect(stream.getStats().bufferedFrames).toBe(1)
+  // EOF bypasses the threshold for a short final chunk.
+  const output = await drive(audio, stream.end())
+  expect(output.some((sample) => sample === 0.5)).toBe(true)
+  expect(stream.getStats().underruns).toBe(1)
+})
+
+test("PCM uses stream, group, master volume and pan through the mixer", async () => {
+  const audio = createAudio()
+  const group = audio.group("pcm")!
+  audio.setGroupVolume(group, 0.5)
+  audio.setMasterVolume(0.5)
+  const stream = audio.createPcmStream(options)
+  stream.setGroup(group)
+  stream.setVolume(0.5)
+  stream.setPan(-1)
+  // Clear must preserve all controls and routing.
+  stream.clear()
+  await stream.write(new Float32Array(960).fill(0.5))
+  const output = audio.mixFrames(128)!
+  expect(output[254]).toBeCloseTo(0.0625)
+  expect(output[255]).toBe(0)
+})
+
+for (const [inputRate, outputRate] of [
+  [8000, 48000],
+  [44100, 48000],
+  [48000, 44100],
+  [96000, 48000],
+  [192000, 8000],
+]) {
+  test(`PCM ${inputRate} to ${outputRate} resampling preserves tone, duration, mono and chunk continuity`, async () => {
+    const input = Float32Array.from(
+      { length: Math.floor(inputRate * 0.04) },
+      (_, i) => Math.sin((2 * Math.PI * 500 * i) / inputRate) * 0.25,
+    )
+    async function render(chunkFrames: number): Promise<Float32Array> {
+      const audio = createAudio(outputRate)
+      const stream = audio.createPcmStream({
+        sampleRate: inputRate,
+        channels: 1,
+        buffer: { capacityMs: 100, startupMs: 1, resumeMs: 1 },
+      })
+      for (let i = 0; i < input.length; i += chunkFrames) await stream.write(input.subarray(i, i + chunkFrames))
+      const output = await drive(audio, stream.end())
+      const stats = stream.getStats()
+      expect(stats.framesWritten).toBe(BigInt(input.length))
+      expect(stats.framesPlayed).toBe(stats.framesConverted)
+      // Miniaudio includes its short resampler delay/tail in output frames.
+      expect(Number(stats.framesPlayed)).toBeGreaterThanOrEqual(Math.floor(outputRate * 0.04))
+      expect(Number(stats.framesPlayed)).toBeLessThan(Math.ceil(outputRate * 0.045))
+      const audible = output.slice(0, Number(stats.framesPlayed) * 2)
+      for (let i = 0; i < audible.length; i += 2) expect(audible[i]).toBeCloseTo(audible[i + 1], 6)
+      let crossings = 0
+      for (let i = 2; i < audible.length; i += 2) if (audible[i - 2] < 0 && audible[i] >= 0) crossings++
+      expect(crossings).toBeGreaterThanOrEqual(19)
+      expect(crossings).toBeLessThanOrEqual(21)
+      return audible
+    }
+    const whole = await render(input.length)
+    const fragmented = await render(7)
+    expect(fragmented.length).toBe(whole.length)
+    for (let i = 0; i < whole.length; i++) expect(fragmented[i]).toBeCloseTo(whole[i], 5)
+  })
+}
+
+test("PCM graceful end waits for a write, is idempotent, and frees its voice", async () => {
+  const audio = createAudio()
+  const stream = audio.createPcmStream(options)
+  const write = stream.write(new Float32Array(4000).fill(0.1))
+  const end = stream.end()
+  expect(stream.end()).toBe(end)
+  await expect(stream.write(new Float32Array(2))).rejects.toThrow("input has ended")
+  expect(() => stream.clear()).toThrow("input has ended")
+  await drive(audio, end)
+  await write
+  await stream.closed
+  expect(stream.getStats().framesPlayed).toBe(2000n)
+  expect(audio.getStats()!.voicesActive).toBe(0)
+  stream.dispose()
+  expect(stream.state).toBe("ended")
+})
+
+test("PCM disposal and AbortSignal interrupt blocked writes and drains", async () => {
+  for (const mode of ["stream", "owner", "signal"] as const) {
+    const audio = createAudio()
+    const controller = new AbortController()
+    const stream = audio.createPcmStream({ ...options, signal: controller.signal })
+    const write = stream.write(new Float32Array(10000))
+    const end = stream.end()
+    const results = Promise.allSettled([write, end])
+    if (mode === "stream") stream.dispose()
+    else if (mode === "owner") audio.dispose()
+    else controller.abort()
+    for (const result of await results) {
+      expect(result.status).toBe("rejected")
+      if (result.status === "rejected") expect(result.reason.name).toBe("AbortError")
+    }
+    await stream.closed
+    expect(stream.state).toBe("disposed")
+  }
+})
+
+test("PCM rejects malformed input, supports cross-realm arrays, and closes on native write failure", async () => {
+  const audio = createAudio()
+  for (const sampleRate of [0, NaN, 1.5, 7999, 192001]) {
+    expect(() => audio.createPcmStream({ ...options, sampleRate })).toThrow()
+  }
+  expect(() => audio.createPcmStream({ ...options, channels: 3 as 2 })).toThrow()
+  expect(() => audio.createPcmStream({ ...options, signal: AbortSignal.abort() })).toThrow()
+  const stream = audio.createPcmStream(options)
+  await expect(stream.write(new Float32Array(1))).rejects.toThrow("whole interleaved frames")
+  await expect(stream.write(new Uint8Array(2) as unknown as Float32Array)).rejects.toThrow("Float32Array")
+  await expect(stream.write(new Float32Array(new SharedArrayBuffer(8)))).rejects.toThrow("non-shared")
+  await stream.write(runInNewContext("new Float32Array([0.25, 0.5])"))
+  const errors: AudioStreamError[] = []
+  stream.on("error", (error) => errors.push(error))
+  const failure = await stream.write(new Float32Array([Infinity, 0])).catch((error: unknown) => error)
+  expect(failure).toBeInstanceOf(AudioStreamError)
+  await stream.closed
+  expect(stream.state).toBe("errored")
+  expect(stream.error).toBe(errors[0])
+  expect(stream.error!.context.action).toBe("write")
+  expect(audio.getStats()!.voicesActive).toBe(0)
+})
+
+test("PCM empty EOF requires no mixer and native close failure retains owner for retry", async () => {
+  const audio = createAudio()
+  audio.stop()
+  const empty = audio.createPcmStream(options)
+  await empty.end()
+  expect(empty.getStats().framesConverted).toBe(0n)
+  const stream = audio.createPcmStream(options)
+  const lib = resolveRenderLib()
+  const original = lib.audioCloseStream
+  lib.audioCloseStream = () => ({ status: -5, stats: null })
+  try {
+    expect(() => audio.dispose()).toThrow("destroy failed")
+    expect(audio.getStats()).not.toBeNull()
+  } finally {
+    lib.audioCloseStream = original
+  }
+  audio.dispose()
+  await stream.closed
+  expect(stream.state).toBe("disposed")
+})
+
+test("PCM drain stays paused until resume and clear does not affect another stream", async () => {
+  const audio = createAudio()
+  const first = audio.createPcmStream(options)
+  const second = audio.createPcmStream(options)
+  await first.write(new Float32Array(960).fill(0.25))
+  await second.write(new Float32Array(960).fill(0.125))
+  first.clear()
+  second.pause()
+  let done = false
+  const end = second.end().then(() => {
+    done = true
+  })
+  await new Promise((resolve) => setTimeout(resolve, 10))
+  expect(audio.mixFrames(128)!.every((sample) => sample === 0)).toBe(true)
+  expect(done).toBe(false)
+  expect(second.getStats().bufferedFrames).toBe(480)
+  second.resume()
+  const output = await drive(audio, end)
+  expect(output.some((sample) => sample === 0.125)).toBe(true)
+  expect(output.every((sample) => sample <= 0.125)).toBe(true)
+  expect(first.getStats().framesPlayed).toBe(0n)
+})
+
+test("PCM streams share voice limits and release slots after disposal", async () => {
+  const audio = createAudio()
+  const streams = Array.from({ length: 32 }, () => audio.createPcmStream(options))
+  expect(() => audio.createPcmStream(options)).toThrow("create failed")
+  expect(audio.getStats()!.voicesActive).toBe(32)
+  streams[0].dispose()
+  const replacement = audio.createPcmStream(options)
+  await replacement.end()
+  expect(audio.getStats()!.voicesActive).toBe(31)
+})
+
+test("PCM stats failure closes playback and removes the original abort listener", async () => {
+  const audio = createAudio()
+  const controller = new AbortController()
+  const mutableOptions = { ...options, signal: controller.signal }
+  const stream = audio.createPcmStream(mutableOptions)
+  expect(getEventListeners(controller.signal, "abort")).toHaveLength(1)
+  mutableOptions.signal = new AbortController().signal
+  const lib = resolveRenderLib()
+  const original = lib.audioGetStreamStats
+  lib.audioGetStreamStats = () => null
+  try {
+    expect(() => stream.getStats()).toThrow("stats unavailable")
+  } finally {
+    lib.audioGetStreamStats = original
+  }
+  await stream.closed
+  expect(stream.state).toBe("errored")
+  expect(stream.error!.context.action).toBe("stats")
+  expect(audio.getStats()!.voicesActive).toBe(0)
+  expect(getEventListeners(controller.signal, "abort")).toHaveLength(0)
+  controller.abort()
+  expect(stream.state).toBe("errored")
+})

--- a/packages/core/src/tests/ffi-borrowed-pointer-callsites.test.ts
+++ b/packages/core/src/tests/ffi-borrowed-pointer-callsites.test.ts
@@ -81,6 +81,45 @@ function readPackedColor(packed: ArrayBuffer, offset: number): number[] {
 }
 
 describe("borrowed pointer call sites", () => {
+  test("PCM creation borrows typed options/output and writes borrow the exact offset view", () => {
+    const create = symbols.audioCreatePcmStream
+    const write = symbols.audioWritePcmStream
+    const input = new Float32Array(10).subarray(2, 8)
+    symbols.audioCreatePcmStream = (_engine, packed: Uint8Array, rate, channels, output: Uint32Array) => {
+      expect(packed).toBeInstanceOf(Uint8Array)
+      expect(AudioStreamCreateOptionsStruct.unpack(packed.buffer as ArrayBuffer).capacityMs).toBe(500)
+      expect(rate).toBe(44100)
+      expect(channels).toBe(2)
+      expect(output).toBeInstanceOf(Uint32Array)
+      output[0] = 257
+      return 0
+    }
+    symbols.audioWritePcmStream = (_engine, id, view, samples) => {
+      expect(id).toBe(257)
+      expect(view).toBe(input)
+      expect(samples).toBe(6)
+      return 3
+    }
+    try {
+      expect(
+        lib.audioCreatePcmStream(1 as any, {
+          sampleRate: 44100,
+          channels: 2,
+          capacityMs: 500,
+          startupMs: 20,
+          resumeMs: 20,
+          volume: 1,
+          pan: 0,
+          groupId: 0,
+        }),
+      ).toEqual({ status: 0, streamId: 257 })
+      expect(lib.audioWritePcmStream(1 as any, 257, input)).toBe(3)
+    } finally {
+      symbols.audioCreatePcmStream = create
+      symbols.audioWritePcmStream = write
+    }
+  })
+
   test("passes reusable struct views through the native FFI boundary", () => {
     const buffer = lib.createEditBuffer("wcwidth")
     try {

--- a/packages/core/src/zig-structs.ts
+++ b/packages/core/src/zig-structs.ts
@@ -426,6 +426,11 @@ export type NativeAudioStreamStats = {
   readyGeneration: number
 }
 
+export type AudioPcmStreamCreateOptions = Omit<AudioStreamCreateOptions, "format" | "maxProbeBytes"> & {
+  sampleRate: number
+  channels: number
+}
+
 export const NativeAudioStreamState = {
   Initializing: 0,
   Buffering: 1,
@@ -434,6 +439,7 @@ export const NativeAudioStreamState = {
   Failed: 4,
   Cancelled: 5,
   Reconnecting: 6,
+  Paused: 7,
 } as const
 
 export type NativeAudioStreamState = (typeof NativeAudioStreamState)[keyof typeof NativeAudioStreamState]

--- a/packages/core/src/zig.ts
+++ b/packages/core/src/zig.ts
@@ -30,6 +30,7 @@ export type {
   LineInfo,
   AllocatorStats,
   AudioStreamCreateOptions,
+  AudioPcmStreamCreateOptions,
   BuildOptions,
   NativeAudioCaptureStats,
   NativeAudioStreamStats,
@@ -81,6 +82,7 @@ import type {
   AudioStartOptions,
   AudioVoiceOptions,
   AudioStreamCreateOptions,
+  AudioPcmStreamCreateOptions,
   NativeAudioStreamCloseReason as NativeAudioStreamCloseReasonType,
   NativeAudioStreamFormat as NativeAudioStreamFormatType,
   NativeAudioStreamState as NativeAudioStreamStateType,
@@ -1948,6 +1950,26 @@ function getOpenTUILib(libPath?: string) {
       args: ["u32", "u32", "ptr", "u32"],
       returns: "i32",
     },
+    audioCreatePcmStream: {
+      args: ["u32", "buffer", "u32", "u32", "buffer"],
+      returns: "i32",
+    },
+    audioWritePcmStream: {
+      args: ["u32", "u32", "buffer", "u32"],
+      returns: "i32",
+    },
+    audioEndPcmStream: {
+      args: ["u32", "u32"],
+      returns: "i32",
+    },
+    audioSetPcmStreamPaused: {
+      args: ["u32", "u32", "u8"],
+      returns: "i32",
+    },
+    audioClearPcmStream: {
+      args: ["u32", "u32"],
+      returns: "i32",
+    },
     audioEndStream: {
       args: ["u32", "u32"],
       returns: "i32",
@@ -2405,6 +2427,14 @@ export interface AudioEngineLib {
     options: AudioStreamCreateOptions,
   ) => { status: number; streamId: number | null }
   audioWriteStream: (engine: AudioEngineHandle, streamId: number, data: Uint8Array) => number
+  audioCreatePcmStream: (
+    engine: AudioEngineHandle,
+    options: AudioPcmStreamCreateOptions,
+  ) => { status: number; streamId: number | null }
+  audioWritePcmStream: (engine: AudioEngineHandle, streamId: number, data: Float32Array) => number
+  audioEndPcmStream: (engine: AudioEngineHandle, streamId: number) => number
+  audioSetPcmStreamPaused: (engine: AudioEngineHandle, streamId: number, paused: boolean) => number
+  audioClearPcmStream: (engine: AudioEngineHandle, streamId: number) => number
   audioEndStream: (engine: AudioEngineHandle, streamId: number) => number
   audioRestartStream: (engine: AudioEngineHandle, streamId: number) => number
   audioSetStreamVolume: (engine: AudioEngineHandle, streamId: number, volume: number) => number
@@ -6353,6 +6383,45 @@ class FFIRenderLib implements RenderLib {
     const status = this.opentui.symbols.audioCreateStream(engine, optionsBuffer, outBuffer)
     if (status !== 0) return { status, streamId: null }
     return { status, streamId: new Uint32Array(outBuffer)[0] ?? null }
+  }
+
+  public audioCreatePcmStream(
+    engine: AudioEngineHandle,
+    options: AudioPcmStreamCreateOptions,
+  ): { status: number; streamId: number | null } {
+    if (!isFFIU32(options.groupId) || !isFFIU32(options.sampleRate) || !isFFIU32(options.channels)) {
+      return { status: -1, streamId: null }
+    }
+    const packed = new Uint8Array(AudioStreamCreateOptionsStruct.pack({ ...options, format: 0, maxProbeBytes: 0 }))
+    const output = new Uint32Array(1)
+    const status = this.opentui.symbols.audioCreatePcmStream(
+      engine,
+      packed,
+      options.sampleRate,
+      options.channels,
+      output,
+    )
+    return { status, streamId: status === 0 ? output[0]! : null }
+  }
+
+  public audioWritePcmStream(engine: AudioEngineHandle, streamId: number, data: Float32Array): number {
+    if (!ArrayBuffer.isView(data) || Object.prototype.toString.call(data) !== "[object Float32Array]") {
+      throw new TypeError("PCM data must be a Float32Array")
+    }
+    const length = toSafeFFIU32Length(data.length, "PCM sample count")
+    return this.opentui.symbols.audioWritePcmStream(engine, streamId, data, length)
+  }
+
+  public audioEndPcmStream(engine: AudioEngineHandle, streamId: number): number {
+    return this.opentui.symbols.audioEndPcmStream(engine, streamId)
+  }
+
+  public audioSetPcmStreamPaused(engine: AudioEngineHandle, streamId: number, paused: boolean): number {
+    return this.opentui.symbols.audioSetPcmStreamPaused(engine, streamId, paused ? 1 : 0)
+  }
+
+  public audioClearPcmStream(engine: AudioEngineHandle, streamId: number): number {
+    return this.opentui.symbols.audioClearPcmStream(engine, streamId)
   }
 
   public audioWriteStream(engine: AudioEngineHandle, streamId: number, data: Uint8Array): number {

--- a/packages/core/tsconfig.node-test.json
+++ b/packages/core/tsconfig.node-test.json
@@ -103,6 +103,7 @@
     "src/tests/renderable.snapshot.test.ts",
     "src/tests/allocator-stats.test.ts",
     "src/tests/audio-stream.test.ts",
+    "src/tests/audio-pcm-stream.test.ts",
     "src/tests/clipboard-native-lifecycle.test.ts",
     "src/tests/audio.test.ts",
     "src/tests/image-icc-allocation-child.ts",

--- a/packages/examples/src/pcm-playback.ts
+++ b/packages/examples/src/pcm-playback.ts
@@ -1,0 +1,36 @@
+#!/usr/bin/env bun
+
+// Run: bun src/pcm-playback.ts [--headless]
+import { Audio } from "@opentui/core"
+
+const headless = process.argv.includes("--headless")
+const audio = Audio.create({ autoStart: false })
+const controller = new AbortController()
+const onInterrupt = () => controller.abort()
+process.once("SIGINT", onInterrupt)
+audio.on("error", (error) => console.error(error.message))
+let mixer: ReturnType<typeof setInterval> | undefined
+
+try {
+  if (!(headless ? audio.startMixer() : audio.start())) throw new Error("Unable to start audio output")
+  if (headless) mixer = setInterval(() => audio.mixFrames(480), 10)
+  const stream = audio.createPcmStream({ sampleRate: 44100, channels: 1, signal: controller.signal })
+  // A generated source can reuse this allocation after each awaited write.
+  const chunk = new Float32Array(441)
+  for (let offset = 0; offset < 44100 * 2; offset += chunk.length) {
+    for (let i = 0; i < chunk.length; i++) {
+      const time = (offset + i) / 44100
+      const envelope = Math.min(1, time * 20, (2 - time) * 20)
+      chunk[i] = Math.sin(2 * Math.PI * 440 * time) * 0.15 * envelope
+    }
+    await stream.write(chunk)
+  }
+  await stream.end()
+  console.log(stream.getStats())
+} catch (error) {
+  if (!(error instanceof Error && error.name === "AbortError")) throw error
+} finally {
+  if (mixer !== undefined) clearInterval(mixer)
+  process.removeListener("SIGINT", onInterrupt)
+  audio.dispose()
+}

--- a/packages/native/src/audio.zig
+++ b/packages/native/src/audio.zig
@@ -20,6 +20,10 @@ const stream_input_capacity: u32 = 256 * 1024;
 // Bounds endless invalid input during decoder setup; StreamOptions can raise it for valid metadata.
 pub const default_stream_probe_bytes: u32 = 1024 * 1024;
 const stream_decoder_chunk_frames: u32 = 2_048;
+// PCM conversion runs on the calling thread, with bounded work per FFI call.
+pub const pcm_write_batch_frames: u32 = 2_048;
+pub const min_pcm_sample_rate: u32 = 8_000;
+pub const max_pcm_sample_rate: u32 = 192_000;
 // Coalesce tiny transport fragments without waiting for miniaudio's full decoder read request.
 const stream_decoder_read_granularity: usize = 2 * 1024;
 const max_stream_generation: u32 = 0x00ffffff;
@@ -84,6 +88,7 @@ pub const StreamState = struct {
     pub const failed: u32 = 4;
     pub const cancelled: u32 = 5;
     pub const reconnecting: u32 = 6;
+    pub const paused: u32 = 7;
 };
 
 pub const StreamStats = extern struct {
@@ -317,6 +322,14 @@ const Stream = struct {
     error_code: i32 = 0,
     ready_generation: u32 = 0,
     has_started_playback: bool = false,
+    pcm_converter: c.ma_data_converter = undefined,
+    pcm_converter_ready: bool = false,
+    pcm_input_rate: u32 = 0,
+    pcm_input_channels: u32 = 0,
+    pcm_input_frames: u64 = 0,
+    pcm_output_frames: u64 = 0,
+    paused: bool = false,
+    group_id: u32 = 0,
 };
 
 const SoundGroup = struct {
@@ -611,6 +624,7 @@ fn destroyStreamStorage(stream: *Stream, out_final_stats: ?*StreamStats) void {
         c.ma_pcm_rb_uninit(&stream.pcm_ring);
         stream.pcm_ring_ready = false;
     }
+    if (stream.pcm_converter_ready) c.ma_data_converter_uninit(&stream.pcm_converter, null);
     stream.allocator.free(stream.pcm_buffer);
     stream.allocator.free(stream.input_buffer);
     stream.allocator.destroy(stream);
@@ -1684,11 +1698,37 @@ fn retireStreamSlotLocked(engine: *Engine, slot_index: usize) void {
     engine.stream_generations[slot_index] = if (generation == max_stream_generation) 0 else generation + 1;
 }
 
+fn initStreamSound(engine: *Engine, stream: *Stream, volume: f32, pan: f32) i32 {
+    const data_source: *c.ma_data_source = @ptrCast(&stream.source);
+    const flags: c.ma_uint32 = c.MA_SOUND_FLAG_NO_SPATIALIZATION | c.MA_SOUND_FLAG_NO_PITCH;
+    if (c.ma_sound_init_from_data_source(&engine.core, data_source, flags, &engine.groups.items[stream.group_id].node, &stream.sound) != c.MA_SUCCESS) return Status.err_device;
+    stream.sound_ready = true;
+    c.ma_sound_set_pan(&stream.sound, clamp(pan, -1, 1));
+    c.ma_sound_set_volume(&stream.sound, clamp(volume, 0, 4));
+    if (!stream.paused and c.ma_sound_start(&stream.sound) != c.MA_SUCCESS) {
+        c.ma_sound_uninit(&stream.sound);
+        stream.sound_ready = false;
+        return Status.err_device;
+    }
+    return Status.ok;
+}
+
 pub fn createStream(engine: *Engine, options_ptr: ?*const StreamOptions, out_stream_id: ?*u32) i32 {
     if (options_ptr == null or out_stream_id == null) return Status.err_invalid;
     const options = options_ptr.?.*;
     if (options.max_probe_bytes == 0 or
         (options.format != StreamFormat.mp3 and options.format != StreamFormat.flac)) return Status.err_invalid;
+    return createStreamInternal(engine, options, 0, 0, out_stream_id.?);
+}
+
+pub fn createPcmStream(engine: *Engine, options_ptr: ?*const StreamOptions, sample_rate: u32, channels: u32, out_stream_id: ?*u32) i32 {
+    if (options_ptr == null or out_stream_id == null or channels < 1 or channels > 2 or
+        sample_rate < min_pcm_sample_rate or sample_rate > max_pcm_sample_rate or
+        engine.sample_rate < min_pcm_sample_rate or engine.sample_rate > max_pcm_sample_rate) return Status.err_invalid;
+    return createStreamInternal(engine, options_ptr.?.*, sample_rate, channels, out_stream_id.?);
+}
+
+fn createStreamInternal(engine: *Engine, options: StreamOptions, input_rate: u32, input_channels: u32, out_stream_id: *u32) i32 {
     const frame_options = resolveStreamFrameOptions(options, engine.sample_rate) orelse return Status.err_invalid;
 
     const e = engine;
@@ -1703,14 +1743,14 @@ pub fn createStream(engine: *Engine, options_ptr: ?*const StreamOptions, out_str
 
         for (e.streams, 0..) |existing_stream, slot_index| {
             if (existing_stream == null and e.stream_generations[slot_index] != 0) {
-                break :blk .{ .group_index = group_index, .slot_index = slot_index };
+                break :blk .{ .slot_index = slot_index };
             }
         }
         return Status.err_no_space;
     };
 
     const stream = e.allocator.create(Stream) catch return Status.err_no_space;
-    const input_buffer = e.allocator.alloc(u8, stream_input_capacity) catch {
+    const input_buffer = e.allocator.alloc(u8, if (input_rate == 0) stream_input_capacity else 0) catch {
         e.allocator.destroy(stream);
         return Status.err_no_space;
     };
@@ -1735,8 +1775,22 @@ pub fn createStream(engine: *Engine, options_ptr: ?*const StreamOptions, out_str
         .format = options.format,
         .sample_rate = e.sample_rate,
         .capacity_frames = frame_options.capacity_frames,
+        .pcm_input_rate = input_rate,
+        .pcm_input_channels = input_channels,
+        .group_id = options.group_id,
     };
     stream.source.stream = stream;
+
+    if (input_rate != 0) {
+        const config = c.ma_data_converter_config_init(c.ma_format_f32, c.ma_format_f32, input_channels, 2, input_rate, e.sample_rate);
+        if (c.ma_data_converter_init(&config, null, &stream.pcm_converter) != c.MA_SUCCESS) {
+            destroyStreamStorage(stream, null);
+            return Status.err_device;
+        }
+        stream.pcm_converter_ready = true;
+        stream.state = StreamState.buffering;
+        stream.ready_generation = 1;
+    }
 
     if (c.ma_pcm_rb_init(c.ma_format_f32, 2, frame_options.capacity_frames, pcm_buffer.ptr, null, &stream.pcm_ring) != c.MA_SUCCESS) {
         destroyStreamStorage(stream, null);
@@ -1754,19 +1808,7 @@ pub fn createStream(engine: *Engine, options_ptr: ?*const StreamOptions, out_str
     stream.source_ready = true;
 
     e.lock.lockUncancelable(io);
-    const data_source: *c.ma_data_source = @ptrCast(&stream.source);
-    const sound_flags: c.ma_uint32 = c.MA_SOUND_FLAG_NO_SPATIALIZATION | c.MA_SOUND_FLAG_NO_PITCH;
-    if (c.ma_sound_init_from_data_source(&e.core, data_source, sound_flags, &e.groups.items[preflight.group_index].node, &stream.sound) != c.MA_SUCCESS) {
-        e.lock.unlock(io);
-        destroyStreamStorage(stream, null);
-        return Status.err_device;
-    }
-    stream.sound_ready = true;
-    c.ma_sound_set_pan(&stream.sound, clamp(options.pan, -1, 1));
-    c.ma_sound_set_volume(&stream.sound, clamp(options.volume, 0, 4));
-    if (c.ma_sound_start(&stream.sound) != c.MA_SUCCESS) {
-        c.ma_sound_uninit(&stream.sound);
-        stream.sound_ready = false;
+    if (initStreamSound(e, stream, options.volume, options.pan) != Status.ok) {
         e.lock.unlock(io);
         destroyStreamStorage(stream, null);
         return Status.err_device;
@@ -1778,7 +1820,7 @@ pub fn createStream(engine: *Engine, options_ptr: ?*const StreamOptions, out_str
     e.updateActiveVoiceCount();
     e.lock.unlock(io);
 
-    stream.worker = std.Thread.spawn(.{}, streamDecoderWorker, .{stream}) catch {
+    if (input_rate == 0) stream.worker = std.Thread.spawn(.{}, streamDecoderWorker, .{stream}) catch {
         e.lock.lockUncancelable(io);
         if (stream.sound_ready) {
             _ = c.ma_sound_stop(&stream.sound);
@@ -1792,7 +1834,97 @@ pub fn createStream(engine: *Engine, options_ptr: ?*const StreamOptions, out_str
         return Status.err_no_space;
     };
 
-    out_stream_id.?.* = stream_id;
+    out_stream_id.* = stream_id;
+    return Status.ok;
+}
+
+// Called with the engine lock held: the ring consumer and clear/dispose are excluded.
+// Miniaudio retains conversion history, never the borrowed input pointer.
+fn convertPcm(stream: *Stream, input: ?[*]const f32, input_frames: u32, output_limit: u64) i32 {
+    var contiguous: u32 = @intCast(@min(c.ma_pcm_rb_available_write(&stream.pcm_ring), pcm_write_batch_frames, output_limit));
+    if (contiguous == 0) return 0;
+    var output: ?*anyopaque = null;
+    if (c.ma_pcm_rb_acquire_write(&stream.pcm_ring, &contiguous, &output) != c.MA_SUCCESS or output == null) return Status.err_device;
+    var consumed: u64 = @min(input_frames, pcm_write_batch_frames);
+    var produced: u64 = contiguous;
+    if (c.ma_data_converter_process_pcm_frames(&stream.pcm_converter, input, &consumed, output, &produced) != c.MA_SUCCESS or
+        c.ma_pcm_rb_commit_write(&stream.pcm_ring, @intCast(produced)) != c.MA_SUCCESS) return Status.err_device;
+    stream.pcm_output_frames += produced;
+    _ = @atomicRmw(u64, &stream.frames_decoded, .Add, produced, .monotonic);
+    return @intCast(consumed);
+}
+
+pub fn writePcmStream(engine: *Engine, stream_id: u32, input: ?[*]const f32, sample_count: u32) i32 {
+    engine.lock.lockUncancelable(io);
+    defer engine.lock.unlock(io);
+    const stream = getStream(engine, stream_id) orelse return Status.err_not_found;
+    if (!stream.pcm_converter_ready or sample_count % stream.pcm_input_channels != 0 or
+        (sample_count > 0 and input == null) or stream.input_ended != 0 or isTerminalStreamState(loadStreamState(stream))) return Status.err_invalid;
+    const frames = @min(sample_count / stream.pcm_input_channels, pcm_write_batch_frames);
+    if (frames == 0) return 0;
+    for (input.?[0 .. frames * stream.pcm_input_channels]) |sample| {
+        if (!std.math.isFinite(sample)) return Status.err_invalid;
+    }
+    const consumed = convertPcm(stream, input, frames, pcm_write_batch_frames);
+    if (consumed < 0) return consumed;
+    stream.pcm_input_frames += @intCast(consumed);
+    _ = @atomicRmw(u64, &stream.bytes_received, .Add, @as(u64, @intCast(consumed)) * stream.pcm_input_channels * @sizeOf(f32), .monotonic);
+    return consumed;
+}
+
+// 1 means the converter tail still needs ring space; callers retry with backpressure.
+pub fn endPcmStream(engine: *Engine, stream_id: u32) i32 {
+    engine.lock.lockUncancelable(io);
+    defer engine.lock.unlock(io);
+    const stream = getStream(engine, stream_id) orelse return Status.err_not_found;
+    if (!stream.pcm_converter_ready or loadStreamState(stream) == StreamState.failed) return Status.err_invalid;
+    stream.input_ended = 1;
+    const target: u64 = if (stream.pcm_input_frames == 0) 0 else @intCast(
+        (@as(u128, stream.pcm_input_frames) * stream.sample_rate + stream.pcm_input_rate - 1) / stream.pcm_input_rate +
+            c.ma_data_converter_get_output_latency(&stream.pcm_converter),
+    );
+    if (stream.pcm_output_frames < target) {
+        const result = convertPcm(stream, null, pcm_write_batch_frames, target - stream.pcm_output_frames);
+        if (result < 0) return result;
+        if (stream.pcm_output_frames < target) return 1;
+    }
+    @atomicStore(u32, &stream.decoder_finished, 1, .release);
+    // Empty EOF must also finish without a running mixer.
+    if (c.ma_pcm_rb_available_read(&stream.pcm_ring) == 0) endStreamPlayback(stream);
+    return Status.ok;
+}
+
+pub fn setPcmStreamPaused(engine: *Engine, stream_id: u32, paused: bool) i32 {
+    engine.lock.lockUncancelable(io);
+    defer engine.lock.unlock(io);
+    const stream = getStream(engine, stream_id) orelse return Status.err_not_found;
+    if (!stream.pcm_converter_ready or isTerminalStreamState(loadStreamState(stream))) return Status.err_invalid;
+    const result = if (paused) c.ma_sound_stop(&stream.sound) else c.ma_sound_start(&stream.sound);
+    if (result != c.MA_SUCCESS) return Status.err_device;
+    stream.paused = paused;
+    return Status.ok;
+}
+
+pub fn clearPcmStream(engine: *Engine, stream_id: u32) i32 {
+    engine.lock.lockUncancelable(io);
+    defer engine.lock.unlock(io);
+    const stream = getStream(engine, stream_id) orelse return Status.err_not_found;
+    if (!stream.pcm_converter_ready or stream.input_ended != 0 or isTerminalStreamState(loadStreamState(stream))) return Status.err_invalid;
+    const volume = c.ma_sound_get_volume(&stream.sound);
+    const pan = c.ma_sound_get_pan(&stream.sound);
+    // Discard miniaudio read-ahead as well as the ring and resampler history.
+    c.ma_sound_uninit(&stream.sound);
+    stream.sound_ready = false;
+    c.ma_pcm_rb_reset(&stream.pcm_ring);
+    _ = c.ma_data_converter_reset(&stream.pcm_converter);
+    stream.pcm_input_frames = 0;
+    stream.pcm_output_frames = 0;
+    stream.has_started_playback = false;
+    setStreamState(stream, StreamState.buffering);
+    if (initStreamSound(engine, stream, volume, pan) != Status.ok) {
+        failStreamWithCode(stream, Status.err_device);
+        return Status.err_device;
+    }
     return Status.ok;
 }
 
@@ -1812,7 +1944,7 @@ pub fn writeStream(
 
     stream.input_lock.lockUncancelable(io);
     defer stream.input_lock.unlock(io);
-    if (@atomicLoad(u32, &stream.input_ended, .acquire) != 0 or
+    if (stream.pcm_converter_ready or @atomicLoad(u32, &stream.input_ended, .acquire) != 0 or
         @atomicLoad(u32, &stream.cancel_requested, .acquire) != 0 or
         stream.decoder_abort or isTerminalStreamState(loadStreamState(stream)))
     {
@@ -1845,6 +1977,7 @@ pub fn endStream(engine: *Engine, stream_id: u32) i32 {
     e.lock.lockUncancelable(io);
     defer e.lock.unlock(io);
     const stream = getStream(e, stream_id) orelse return Status.err_not_found;
+    if (stream.pcm_converter_ready) return Status.err_invalid;
 
     stream.input_lock.lockUncancelable(io);
     defer stream.input_lock.unlock(io);
@@ -1960,6 +2093,7 @@ pub fn setStreamGroup(engine: *Engine, stream_id: u32, group_id: u32) i32 {
     if (c.ma_node_attach_output_bus(@ptrCast(&stream.sound), 0, @ptrCast(&e.groups.items[group_index].node), 0) != c.MA_SUCCESS) {
         return Status.err_device;
     }
+    stream.group_id = group_id;
     return Status.ok;
 }
 
@@ -1968,7 +2102,7 @@ fn snapshotStream(stream: *Stream, final: bool) StreamStats {
         .bytes_received = @atomicLoad(u64, &stream.bytes_received, .monotonic),
         .frames_decoded = @atomicLoad(u64, &stream.frames_decoded, .monotonic),
         .frames_played = @atomicLoad(u64, &stream.frames_played, .monotonic),
-        .state = loadStreamState(stream),
+        .state = if (stream.paused and !isTerminalStreamState(loadStreamState(stream))) StreamState.paused else loadStreamState(stream),
         .sample_rate = stream.sample_rate,
         .channels = 2,
         .buffered_frames = if (final) 0 else c.ma_pcm_rb_available_read(&stream.pcm_ring),

--- a/packages/native/src/lib.zig
+++ b/packages/native/src/lib.zig
@@ -993,6 +993,32 @@ export fn audioCreateStream(
     return native_audio.createStream(object_ptr, options_ptr, out_stream_id);
 }
 
+export fn audioCreatePcmStream(engine_handle: NativeHandle, options_ptr: ?*const native_audio.StreamOptions, sample_rate: u32, channels: u32, out_stream_id: ?*u32) i32 {
+    const object_ptr = acquireAudioEngine(engine_handle) orelse return native_audio.Status.err_invalid;
+    return native_audio.createPcmStream(object_ptr, options_ptr, sample_rate, channels, out_stream_id);
+}
+
+export fn audioWritePcmStream(engine_handle: NativeHandle, stream_id: u32, data_ptr: ?[*]const f32, sample_count: u32) i32 {
+    const object_ptr = acquireAudioEngine(engine_handle) orelse return native_audio.Status.err_invalid;
+    return native_audio.writePcmStream(object_ptr, stream_id, data_ptr, sample_count);
+}
+
+export fn audioEndPcmStream(engine_handle: NativeHandle, stream_id: u32) i32 {
+    const object_ptr = acquireAudioEngine(engine_handle) orelse return native_audio.Status.err_invalid;
+    return native_audio.endPcmStream(object_ptr, stream_id);
+}
+
+export fn audioSetPcmStreamPaused(engine_handle: NativeHandle, stream_id: u32, paused: u8) i32 {
+    if (paused > 1) return native_audio.Status.err_invalid;
+    const object_ptr = acquireAudioEngine(engine_handle) orelse return native_audio.Status.err_invalid;
+    return native_audio.setPcmStreamPaused(object_ptr, stream_id, paused != 0);
+}
+
+export fn audioClearPcmStream(engine_handle: NativeHandle, stream_id: u32) i32 {
+    const object_ptr = acquireAudioEngine(engine_handle) orelse return native_audio.Status.err_invalid;
+    return native_audio.clearPcmStream(object_ptr, stream_id);
+}
+
 export fn audioWriteStream(
     engine_handle: NativeHandle,
     stream_id: u32,

--- a/packages/native/src/tests/audio_test.zig
+++ b/packages/native/src/tests/audio_test.zig
@@ -25,6 +25,70 @@ fn streamOptions() audio.StreamOptions {
     };
 }
 
+test "PCM stream copies interleaved input, backpressures, pauses, clears, and drains" {
+    const engine = try createEngine(null);
+    defer audio.destroy(engine);
+    try expectStatusOk(audio.startMixer(engine));
+    var id: u32 = 0;
+    const options = streamOptions();
+    try expectStatusOk(audio.createPcmStream(engine, &options, TEST_SAMPLE_RATE, 2, &id));
+    var input: [960]f32 = undefined;
+    for (0..480) |frame| {
+        input[frame * 2] = 0.25;
+        input[frame * 2 + 1] = -0.5;
+    }
+    try testing.expectEqual(@as(i32, 480), audio.writePcmStream(engine, id, &input, input.len));
+    try testing.expectEqual(@as(i32, 0), audio.writePcmStream(engine, id, &input, input.len));
+    @memset(&input, 0);
+    try expectStatusOk(audio.setPcmStreamPaused(engine, id, true));
+    var output: [256]f32 = undefined;
+    try expectStatusOk(audio.mixToBuffer(engine, &output, 128, 2));
+    try testing.expect(!hasSignal(&output));
+    var stats: audio.StreamStats = undefined;
+    try expectStatusOk(audio.getStreamStats(engine, id, &stats));
+    try testing.expectEqual(@as(u32, 480), stats.buffered_frames);
+    try testing.expectEqual(audio.StreamState.paused, stats.state);
+    try expectStatusOk(audio.setPcmStreamPaused(engine, id, false));
+    try expectStatusOk(audio.mixToBuffer(engine, &output, 128, 2));
+    // The shared mixer group has one frame of processing latency.
+    try testing.expectApproxEqAbs(@as(f32, 0.25), output[2], 0.0001);
+    try testing.expectApproxEqAbs(@as(f32, -0.5), output[3], 0.0001);
+    try expectStatusOk(audio.clearPcmStream(engine, id));
+    try expectStatusOk(audio.mixToBuffer(engine, &output, 128, 2));
+    // Already mixed group history cannot be retracted by clearing one stream.
+    try testing.expect(!hasSignal(output[2..]));
+    try testing.expectEqual(@as(i32, 2), audio.writePcmStream(engine, id, &.{ 0.125, 0.375, 0.125, 0.375 }, 4));
+    try expectStatusOk(audio.endPcmStream(engine, id));
+    try testing.expectEqual(audio.Status.err_invalid, audio.writePcmStream(engine, id, &input, input.len));
+    try expectStatusOk(audio.mixToBuffer(engine, &output, 128, 2));
+    try testing.expectApproxEqAbs(@as(f32, 0.125), output[2], 0.0001);
+    try expectStatusOk(audio.getStreamStats(engine, id, &stats));
+    try testing.expectEqual(audio.StreamState.ended, stats.state);
+    try testing.expectEqual(@as(u64, 482 * 8), stats.bytes_received);
+    try expectStatusOk(audio.closeStream(engine, id, audio.StreamCloseReason.preserve_native_terminal, &stats));
+    try testing.expectEqual(audio.Status.err_not_found, audio.writePcmStream(engine, id, &input, input.len));
+}
+
+test "PCM stream rejects invalid formats and samples and finishes empty EOF" {
+    const engine = try createEngine(null);
+    defer audio.destroy(engine);
+    const options = streamOptions();
+    var id: u32 = 0;
+    try testing.expectEqual(audio.Status.err_invalid, audio.createPcmStream(engine, &options, 0, 2, &id));
+    try testing.expectEqual(audio.Status.err_invalid, audio.createPcmStream(engine, &options, TEST_SAMPLE_RATE, 3, &id));
+    try expectStatusOk(audio.createPcmStream(engine, &options, TEST_SAMPLE_RATE, 2, &id));
+    try testing.expectEqual(audio.Status.err_invalid, audio.writePcmStream(engine, id, &.{0}, 1));
+    try testing.expectEqual(audio.Status.err_invalid, audio.writePcmStream(engine, id, &.{ std.math.nan(f32), 0 }, 2));
+    try testing.expectEqual(audio.Status.err_invalid, audio.writePcmStream(engine, id, null, 2));
+    try testing.expectEqual(audio.Status.err_invalid, audio.writeStream(engine, id, &.{0}, 1));
+    try testing.expectEqual(audio.Status.err_invalid, audio.endStream(engine, id));
+    try expectStatusOk(audio.endPcmStream(engine, id));
+    var stats: audio.StreamStats = undefined;
+    try expectStatusOk(audio.getStreamStats(engine, id, &stats));
+    try testing.expectEqual(audio.StreamState.ended, stats.state);
+    try testing.expectEqual(@as(u64, 0), stats.frames_decoded);
+}
+
 fn buildPcm16Wav(allocator: std.mem.Allocator, channels: u16, sample_rate: u32, samples: []const i16) ![]u8 {
     if (channels == 0 or samples.len == 0) return error.InvalidInput;
     if (samples.len % @as(usize, channels) != 0) return error.InvalidInput;

--- a/packages/web/src/content/SKILL.md
+++ b/packages/web/src/content/SKILL.md
@@ -85,7 +85,7 @@ Use public package entry points instead of source-file deep imports.
 | `embedded-terminal`, `terminal-renderable`, `ghostty`, `vt`, `pty`                                                   | `docs/components/embedded-terminal.mdx`     |
 | `clipboard`, `copy`, `osc52`, `host-clipboard`                                                                       | `docs/core-concepts/clipboard.mdx`          |
 | `audio`, `native-audio`, `sound`, `playback`, `mixer`, `devices`, `tap`                                              | `docs/core-concepts/audio.mdx`              |
-| `audio-streaming`, `audio-stream`, `radio`, `mp3`, `flac`, `icy`, `backpressure`, `reconnect`                        | `docs/application-apis/audio-streaming.mdx` |
+| `audio-streaming`, `audio-stream`, `pcm`, `radio`, `mp3`, `flac`, `icy`, `backpressure`, `reconnect`                 | `docs/application-apis/audio-streaming.mdx` |
 | `audio-capture`, `microphone`, `pcm`, `recording`, `wav`, `audio-recorder`                                           | `docs/application-apis/audio-capture.mdx`   |
 | `animation`, `timeline`, `easing`, `use-timeline`                                                                    | `docs/application-apis/animation.mdx`       |
 | `testing`, `test-renderer`, `snapshots`, `frames`                                                                    | `docs/core-concepts/testing.mdx`            |

--- a/packages/web/src/content/docs/application-apis/audio-streaming.mdx
+++ b/packages/web/src/content/docs/application-apis/audio-streaming.mdx
@@ -1,9 +1,9 @@
 ---
 title: Streaming audio
-description: Play bounded MP3 or FLAC streams from byte sources, URLs, and custom transports
+description: Play bounded PCM, MP3, or FLAC streams through the native audio mixer
 skill:
   entry: true
-  intents: [audio-streaming, audio-stream, radio, mp3, flac, icy, backpressure, reconnect]
+  intents: [audio-streaming, audio-stream, pcm, radio, mp3, flac, icy, backpressure, reconnect]
 ---
 
 # Streaming audio
@@ -11,6 +11,97 @@ skill:
 OpenTUI streams encoded MP3 or FLAC data into the native audio mixer. Streaming starts before the complete source arrives.
 
 Use streaming for long media, internet radio, or a transport that supplies encoded chunks over time. Use [loaded sounds](/docs/core-concepts/audio#load-sounds) for short, reusable audio.
+
+## Write decoded PCM
+
+`audio.createPcmStream()` accepts decoded audio through a bounded writer. Use it for speech synthesis, generated audio, or an external decoder. Applications own their decoder processes, authentication, and playback commands.
+
+```typescript
+import { Audio } from "@opentui/core"
+
+const audio = Audio.create({ autoStart: false })
+audio.on("error", (error) => console.error(error))
+
+try {
+  if (!audio.start()) throw new Error("No playback device is available")
+  const stream = audio.createPcmStream({ sampleRate: 44100, channels: 2 })
+  const chunk = new Float32Array(4410 * 2)
+  for (let frame = 0; frame < 4410; frame++) {
+    const sample = Math.sin((2 * Math.PI * 440 * frame) / 44100) * 0.15
+    chunk[frame * 2] = sample
+    chunk[frame * 2 + 1] = sample
+  }
+  await stream.write(chunk)
+  await stream.end()
+} finally {
+  audio.dispose()
+}
+```
+
+### PCM format and ownership
+
+- Chunks are `Float32Array` views containing finite samples, nominally in `[-1, 1]`. Input is interleaved: mono is one sample per frame; stereo is left, right, left, right. Each chunk must contain whole frames. Empty chunks are accepted.
+- `channels` is `1` or `2`. `sampleRate` is an integer from `8000` through `192000` Hz. The engine rate must be in that range too. Native miniaudio conversion duplicates mono into stereo and resamples to the engine rate, preserving conversion history between chunks.
+- The writer borrows the chunk until `write()` settles. Do not mutate, transfer, or detach its backing memory before then. After settlement, the caller may reuse it. Native code copies or converts accepted frames into its own ring; it retains no JavaScript pointers. Shared backing memory is rejected.
+- Raw byte pipes must be decoded into float32 samples by the consumer. Preserve incomplete samples and frames between pipe reads and honor the helper's byte order. A `Uint8Array` pipe chunk is not a PCM frame chunk.
+
+For an `AsyncIterable<Float32Array>`, await each write:
+
+```typescript
+import type { AudioPcmStream } from "@opentui/core"
+
+async function feed(stream: AudioPcmStream, source: AsyncIterable<Float32Array>): Promise<void> {
+  try {
+    for await (const chunk of source) await stream.write(chunk)
+    await stream.end()
+  } finally {
+    stream.dispose()
+  }
+}
+```
+
+For a `ReadableStream<Float32Array>`, acquire a reader, await `reader.read()` and `stream.write(value)` in sequence, then call `stream.end()` at EOF. Cancel and release the reader when playback is cancelled. Disposing the PCM writer does not cancel an application's pending source read or stop its helper process.
+
+### PCM buffering and controls
+
+Creation is synchronous and returns after native setup succeeds. The stream is ready to accept input immediately. Start the audio device first, or use `audio.startMixer()` and consume `audio.mixFrames()` for headless output.
+
+`buffer` uses the existing `capacityMs`, `startupMs`, and `resumeMs` options. PCM defaults are `500`, `20`, and `20` milliseconds. Values are positive integers; startup and resume thresholds must fit within capacity. Durations are rounded up to whole engine-rate frames.
+
+`write()` resolves when all input has been accepted, not when it has played. Only one write may be pending; another write rejects instead of building an unbounded JavaScript queue. Large chunks are processed in bounded batches. A full ring applies backpressure until the mixer consumes frames. The writer holds only the current caller-owned chunk.
+
+Playback begins at the startup threshold. An underrun emits silence, increments `underruns`, and buffers until the resume threshold. Short final audio plays below those thresholds after EOF.
+
+| Method                                  | Behavior                                                                                                                                                                    |
+| --------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `pause()`                               | Stops consuming queued frames. Writes continue until the ring fills, then wait.                                                                                             |
+| `resume()`                              | Continues playback from the retained queue.                                                                                                                                 |
+| `clear()`                               | Discards the native queue and resampler history. Rejects an unfinished write with `AbortError` and allows a new write immediately. Preserves pause, volume, pan, and group. |
+| `end()`                                 | Seals input, waits for the current write, flushes the conversion tail, drains queued audio, and releases native storage. Repeated calls return the same promise.            |
+| `dispose()`                             | Immediately releases the stream and discards queued audio. Pending writes and `end()` reject with `AbortError`.                                                             |
+| `setVolume()`, `setPan()`, `setGroup()` | Use the same native mixer controls as encoded streams and loaded sounds.                                                                                                    |
+
+For a seek or track switch, stop submitting old chunks, call `clear()`, handle the aborted write, and submit the new position. Input format is fixed for the stream's lifetime; create another writer when the rate or channel count changes. `clear()` is unavailable after `end()` seals input.
+
+Controls affect future mixing. Samples already mixed or submitted to the output device cannot be recalled. `end()` completes when the mixer consumes the stream, rather than when the device physically presents the final sample. Resampling adds a short delay and a zero-padded filter tail. Paused or stopped output must resume to finish a nonempty drain.
+
+### PCM completion and errors
+
+`AudioPcmStream` is an `EventEmitter` with `ended`, `error`, and `disposed` events. `closed` always resolves after native cleanup and the terminal event. `end()` resolves only for a graceful drain; cancellation or failure rejects it. `Audio.dispose()` and the optional `signal` dispose the owned writer.
+
+Creation and control methods throw on failure; writes and drains reject. Argument errors detected before a write leave the stream usable. Native write failures, including non-finite samples discovered during a batch, terminate playback, reject the operation with `AudioStreamError`, and store it in `stream.error`. An `error` event is emitted when a listener is attached. A terminal state and its final statistics remain readable after cleanup.
+
+`state` is the latest snapshot: `buffering`, `playing`, `paused`, `ended`, `errored`, or `disposed`. `getStats()` refreshes it. Statistics include:
+
+- `sampleRate`, `channels`: the stereo mixer-ring format. The writer's own `sampleRate` and `channels` describe input.
+- `bufferedFrames`, `capacityFrames`, `bufferedDurationMs`: queued engine-rate output, excluding device buffers.
+- `framesWritten`: accepted input frames at the input rate.
+- `framesConverted`, `framesPlayed`: engine-rate frames produced and consumed, including conversion delay/tail but excluding underrun silence.
+- `underruns`: transitions from playing to buffering.
+
+Frame counters are `bigint` and cumulative across `clear()`; discarded frames remain counted as written or converted, but not played. Final `bufferedFrames` is zero.
+
+Run the [generated-tone example](https://github.com/anomalyco/opentui/blob/main/packages/examples/src/pcm-playback.ts) from the examples package with `bun src/pcm-playback.ts`. Add `--headless` to exercise conversion and mixing without an output device.
 
 ## Play a URL
 

--- a/packages/web/src/content/docs/core-concepts/audio.mdx
+++ b/packages/web/src/content/docs/core-concepts/audio.mdx
@@ -10,7 +10,7 @@ skill:
 
 OpenTUI plays, mixes, and captures audio through a native miniaudio engine. The `Audio` class in `@opentui/core` owns the engine and its resources.
 
-This page covers the engine and loaded-sound playback. See [Streaming audio](/docs/application-apis/audio-streaming) for encoded byte sources and radio URLs. See [Audio capture and recording](/docs/application-apis/audio-capture) for input devices, Float32 PCM, and WAV files.
+This page covers the engine and loaded-sound playback. See [Streaming audio](/docs/application-apis/audio-streaming) for decoded PCM writers, encoded byte sources, and radio URLs. See [Audio capture and recording](/docs/application-apis/audio-capture) for input devices, Float32 PCM, and WAV files.
 
 ## Play a loaded sound
 
@@ -157,7 +157,7 @@ The device stays open until `stop()` or `dispose()`. Idle voices do not close it
 
 Headless mode makes progress only when the application calls `mixFrames()`. Call it at the output cadence that consumes the requested number of frames.
 
-Loaded voices and encoded streams also need this consumption to advance. A finite stream cannot finish while its decoded PCM remains unconsumed.
+Loaded voices and streams also need this consumption to advance. A finite stream cannot finish while its PCM remains unconsumed.
 
 `stop()` preserves loaded sounds, groups, and their handles. Call `start()` or `startMixer()` before later playback needs to advance.
 
@@ -193,7 +193,7 @@ Selection fails while normal playback or the headless mixer runs. Call `stop()` 
 
 Group and master volumes also clamp to `0..4`. `group(name)` returns the existing group when the same name appears again.
 
-The engine supports 32 active loaded voices and encoded streams in total. A stream reserves one of the same slots.
+The engine supports 32 active loaded voices, encoded streams, and PCM streams in total. A stream reserves one of the same slots.
 
 `AudioSound`, `AudioVoice`, and `AudioGroup` are numeric handles local to one engine. Do not pass them to another `Audio` instance.
 
@@ -215,7 +215,7 @@ Tap reads do not consume data. Repeated reads can return the same latest frames.
 
 Only `framesRead * channels` values in the returned `frames` array contain tapped data. Remaining allocated values contain zero.
 
-The master tap combines loaded sounds and encoded streams. It cannot isolate one voice, group, or stream.
+The master tap combines loaded sounds, encoded streams, and PCM streams. It cannot isolate one voice, group, or stream.
 
 OpenTUI does not calculate a fast Fourier transform (FFT). Run an FFT on tap samples in application code.
 
@@ -224,7 +224,7 @@ OpenTUI does not calculate a fast Fourier transform (FFT). Run an FFT on tap sam
 | Field          | Meaning                                                                 |
 | -------------- | ----------------------------------------------------------------------- |
 | `soundsLoaded` | Loaded sounds that are not unloaded                                     |
-| `voicesActive` | Active loaded voices plus encoded streams                               |
+| `voicesActive` | Active loaded voices plus encoded and PCM streams                       |
 | `framesMixed`  | Frames mixed through device or manual output                            |
 | `lockMisses`   | Device callbacks that returned silence because the engine lock was busy |
 | `lastPeak`     | Peak absolute sample in the last mixed buffer                           |


### PR DESCRIPTION
## Summary

Add `Audio.createPcmStream()` and `AudioPcmStream` for decoded, interleaved `Float32Array` audio: mono/stereo input at 8–192 kHz, converted by miniaudio into the existing bounded stereo ring at the engine rate. Playback uses the existing mixer, output devices, stream/group/master controls, and audio taps.

The writable API provides an immediate control handle and an explicit memory-ownership boundary:

```ts
const stream = audio.createPcmStream({ sampleRate: 44100, channels: 2 })
try {
  for await (const chunk of decodedFrames) await stream.write(chunk)
  await stream.end()
} finally {
  stream.dispose()
}
```

- Single-flight, awaitable writes provide backpressure; callers can reuse chunk memory after settlement. Native conversion and JS pumping use bounded batches.
- `pause()`/`resume()` retain the queue; `clear()` discards queued PCM and conversion history and aborts an unfinished write.
- `end()` flushes conversion history and drains; `dispose()`, `AbortSignal`, and owner disposal cancel immediately. Completion events, `closed`, errors, and cumulative statistics are documented.
- Reuse native stream allocation, data source, sound setup, slot generations, and cleanup. PCM writes use borrowed typed-array FFI buffers and need no decoder worker.
- Add native and Bun/Node coverage for conversion continuity, ownership, mixer/taps, buffering, lifecycle failures, isolation, and voice limits, plus documentation and a runnable generated-tone example.

This supports external decoders such as a consumer-managed librespot pipe, speech synthesis, and generated audio. Applications own source reads, helper processes, authentication, and playback commands. Controls cannot retract samples already mixed or submitted to a device.

## Verification

Tested on macOS arm64 with Zig 0.16.0, Bun 1.4.2, and Node 26.4.0.

- Root `bun run build` — passed.
- Core `bun run test:native` — 2,136 passed, 32 skipped.
- Core `bun run test:js` — 5,682 passed, 26 skipped.
- Core `bun run test:js:node` — 4,935 passed, 7 skipped.
- Core `bun run test:dist --skip-build` and `bun run typecheck` — passed.
- Root `bun run fmt:check` and `bun run lint` — passed.
- Web `bun run validate:docs` and audio-streaming doc example validation — passed.
- Examples `bun run build:host` and `bun src/pcm-playback.ts --headless` — passed; the example drained 88,200 input frames into 96,002 output frames with zero underruns.
