### PR TITLE
fix(native): set contrasting foreground for empty space cells in fillRect

### DIFF
--- a/packages/native/scripts/prepare-zig-deps.sh
+++ b/packages/native/scripts/prepare-zig-deps.sh
@@ -50,7 +50,7 @@ if is_ready; then
 fi
 
 mkdir -p "$TEMP_DIR"
-tar -xzf "$ARCHIVE" -C "$TEMP_DIR"
+tar --force-local -xzf "$ARCHIVE" -C "$TEMP_DIR"
 printf '%s\n' "$ARCHIVE_ID" > "$TEMP_DIR/.ready"
 rm -rf "$DEPS_DIR"
 mv "$TEMP_DIR" "$DEPS_DIR"

--- a/packages/native/src/buffer.zig
+++ b/packages/native/src/buffer.zig
@@ -1053,6 +1053,18 @@ pub const OptimizedBuffer = struct {
         self.setVisibleCellWithAlphaBlending(x, y, cell, opacity, fully_transparent);
     }
 
+    pub inline fn contrastingForeground(bg: RGBA) RGBA {
+        if (ansi.alpha(bg) == 0) {
+            return ansi.defaultColor(255, 255, 255, 255);
+        }
+        const r = ansi.red(bg);
+        const g = ansi.green(bg);
+        const b = ansi.blue(bg);
+        // Relative luminance approximation: 0.2126 R + 0.7152 G + 0.0722 B
+        const lum = (@as(u32, r) * 2126 + @as(u32, g) * 7152 + @as(u32, b) * 722) / 10000;
+        return if (lum >= 128) ansi.rgbColor(0, 0, 0, 255) else ansi.rgbColor(255, 255, 255, 255);
+    }
+
     pub fn fillRect(
         self: *OptimizedBuffer,
         x: u32,
@@ -1087,8 +1099,10 @@ pub const OptimizedBuffer = struct {
         const clippedEndX = @min(endX, @as(u32, @intCast(clippedRect.x + @as(i32, @intCast(clippedRect.width)) - 1)));
         const clippedEndY = @min(endY, @as(u32, @intCast(clippedRect.y + @as(i32, @intCast(clippedRect.height)) - 1)));
 
+        const space_fg = contrastingForeground(bg);
+
         if (fully_transparent) {
-            const cell = makeCell(DEFAULT_SPACE_CHAR, ansi.rgbColor(255, 255, 255, 255), bg, 0);
+            const cell = makeCell(DEFAULT_SPACE_CHAR, space_fg, bg, 0);
             const clipped_area = @as(u64, clippedEndX - clippedStartX + 1) * (clippedEndY - clippedStartY + 1);
             var intersection_area: u64 = 0;
             for (self.image_placements.items) |placement| {
@@ -1145,7 +1159,7 @@ pub const OptimizedBuffer = struct {
                     self.setCellWithAlphaBlendingCell(
                         fillX,
                         fillY,
-                        makeCell(DEFAULT_SPACE_CHAR, ansi.rgbColor(255, 255, 255, 255), bg, 0),
+                        makeCell(DEFAULT_SPACE_CHAR, space_fg, bg, 0),
                     );
                 }
             }
@@ -1157,7 +1171,7 @@ pub const OptimizedBuffer = struct {
             while (fillY <= clippedEndY) : (fillY += 1) {
                 var fillX = clippedStartX;
                 while (fillX <= clippedEndX) : (fillX += 1) {
-                    const cell = makeCell(DEFAULT_SPACE_CHAR, ansi.rgbColor(255, 255, 255, 255), bg, 0);
+                    const cell = makeCell(DEFAULT_SPACE_CHAR, space_fg, bg, 0);
                     if (image_aware) self.setCellWithAlphaBlendingRawImageAware(fillX, fillY, cell) else self.setCellWithAlphaBlendingRawCell(fillX, fillY, cell);
                 }
             }
@@ -1174,7 +1188,7 @@ pub const OptimizedBuffer = struct {
                 const rowSliceAttrs = self.buffer.attributes[rowStartIndex .. rowStartIndex + rowWidth];
 
                 @memset(rowSliceChar, @intCast(DEFAULT_SPACE_CHAR));
-                @memset(rowSliceFg, ansi.rgbColor(255, 255, 255, 255));
+                @memset(rowSliceFg, space_fg);
                 @memset(rowSliceBg, bg);
                 @memset(rowSliceAttrs, 0);
             }

--- a/packages/native/src/tests/buffer_test.zig
+++ b/packages/native/src/tests/buffer_test.zig
@@ -3625,3 +3625,38 @@ test "OptimizedBuffer frame buffer merge multiplies nested placement opacity" {
     // 0.5 * 0.5 = 0.25 -> 64 of 255.
     try std.testing.expect(@abs(@as(i16, target.image_placements.items[0].opacity) - 64) <= 1);
 }
+
+test "OptimizedBuffer - fillRect sets contrasting foreground on light and dark backgrounds" {
+    const pool = gp.initGlobalPool(std.testing.allocator);
+    defer gp.deinitGlobalPool();
+
+    var buf = try OptimizedBuffer.init(
+        std.testing.allocator,
+        10,
+        5,
+        .{ .pool = pool, .id = "test-buffer" },
+    );
+    defer buf.deinit();
+
+    // Fill with light background (e.g. #F5F5F5)
+    const light_bg = ansi.rgbColor(245, 245, 245, 255);
+    buf.fillRect(0, 0, 10, 5, light_bg);
+
+    const light_cell = buf.get(0, 0).?;
+    try std.testing.expectEqual(@as(u32, buffer_mod.DEFAULT_SPACE_CHAR), light_cell.char);
+    // Foreground should contrast with light background -> black (0, 0, 0)
+    try std.testing.expectEqual(@as(u8, 0), ansi.red(light_cell.fg));
+    try std.testing.expectEqual(@as(u8, 0), ansi.green(light_cell.fg));
+    try std.testing.expectEqual(@as(u8, 0), ansi.blue(light_cell.fg));
+
+    // Fill with dark background (e.g. #1E1E1E)
+    const dark_bg = ansi.rgbColor(30, 30, 30, 255);
+    buf.fillRect(0, 0, 10, 5, dark_bg);
+
+    const dark_cell = buf.get(0, 0).?;
+    try std.testing.expectEqual(@as(u32, buffer_mod.DEFAULT_SPACE_CHAR), dark_cell.char);
+    // Foreground should contrast with dark background -> white (255, 255, 255)
+    try std.testing.expectEqual(@as(u8, 255), ansi.red(dark_cell.fg));
+    try std.testing.expectEqual(@as(u8, 255), ansi.green(dark_cell.fg));
+    try std.testing.expectEqual(@as(u8, 255), ansi.blue(dark_cell.fg));
+}


### PR DESCRIPTION
## Summary

When rendering background fills in `OptimizedBuffer.fillRect`, empty space cells (`' '`) were previously filled with a hardcoded white foreground: `ansi.rgbColor(255, 255, 255, 255)`.

### Problem
While a space character has no visible glyph, terminal emulators store its SGR foreground color attribute. On platforms like Windows Terminal (ConPTY), inline IME composition (e.g. Chinese Pinyin, Japanese Hiragana) writes unconfirmed composition characters directly into console cells starting at the cursor position, adopting the existing cell foreground attributes.

- When an input box / textarea has a light background (e.g., `#F5F5F5` or light theme elements) and is filled via `fillRect`, all empty cells have `fg = rgb(255, 255, 255)`.
- When the textarea is empty, placeholder text is rendered at the cursor column, giving the cell at column 0 a dark foreground (e.g. `#666666`), which makes the initial composition readable.
- Once characters are entered and the cursor moves to an empty trailing cell (or any subsequent position), the cell retains `fg = white`. The inline IME preedit/composition string is drawn with this white foreground on a light background, rendering it invisible/unreadable.

### Changes
1. **Contrasting foreground for space cells**: In `packages/native/src/buffer.zig`, compute `contrastingForeground(bg)` based on ITU-R BT.709 relative luminance (`0.2126 R + 0.7152 G + 0.0722 B`).
   - If the background luminance is >= 128, use black foreground (`rgb(0, 0, 0, 255)`).
   - If the background luminance is < 128, use white foreground (`rgb(255, 255, 255, 255)`).
   - If transparent (`alpha == 0`), preserve `ansi.defaultColor()`.
2. **Build script fix**: In `packages/native/scripts/prepare-zig-deps.sh`, add `--force-local` to `tar` extraction to avoid GNU tar treating Windows drive letter colons (such as `C:`) as remote archive hosts.
3. **Automated unit test**: Added `OptimizedBuffer - fillRect sets contrasting foreground on light and dark backgrounds` in `packages/native/src/tests/buffer_test.zig`.

## Validation

- Native tests: `bun run test:native` passed (2,107 passed, 60 skipped, 0 failed).
- Core rendering tests: `bun test src/renderables/__tests__/Textarea.rendering.test.ts` passed (74 passed, 0 failed).
- Formatting & Linting: `bun run fmt:check` and `bun run lint` passed with 0 errors.
