### PR TITLE
fix(core): close owned stdin handle on destroy to prevent Windows console wedge

### DIFF
--- a/packages/core/src/renderer.ts
+++ b/packages/core/src/renderer.ts
@@ -1016,6 +1016,12 @@ export class CliRenderer extends EventEmitter implements RenderContext {
   // identity checks inline (e.g. rendererTracker compares `stdin` directly)
   // or duck-typed capability checks (e.g. `stdin.setRawMode?.()`).
   private readonly _usesProcessStdout: boolean
+  // True only when `stdin` is `process.stdin` and nothing was already consuming
+  // it when the renderer was constructed. `createCliRenderer` puts `process.stdin`
+  // into raw mode, which opens its console-input TTY handle; if we are the ones
+  // who opened it, we must close it on destroy (see `releaseStdinHandle`).
+  // Captured before setup touches stdin.
+  private readonly _ownsStdinHandle: boolean
 
   // Feed wiring. Non-null when the given stdout is not process.stdout and native
   // output is not explicitly redirected to a buffered memory destination.
@@ -1065,6 +1071,7 @@ export class CliRenderer extends EventEmitter implements RenderContext {
     this.stdin = stdin
     this.stdout = stdout
     this._usesProcessStdout = stdout === process.stdout
+    this._ownsStdinHandle = stdin === process.stdin && stdin.listenerCount("data") === 0
     this.realStdoutWrite = stdout.write
 
     const lib = resolveRenderLib()
@@ -4474,6 +4481,7 @@ export class CliRenderer extends EventEmitter implements RenderContext {
     } catch (e) {
       console.error("Error pausing stdin during destroy:", e)
     }
+    this.releaseStdinHandle()
 
     if (this._feed !== null && this._splitHeight > 0 && !this._terminalIsSetup) {
       this.flushPendingSplitOutputBeforeTransition(false, { allowSuspended: true, allowUnsetup: true })
@@ -4483,6 +4491,40 @@ export class CliRenderer extends EventEmitter implements RenderContext {
 
     if (this._splitHeight > 0) {
       this.flushStdoutCache(this._splitHeight, true)
+    }
+  }
+
+  // Close the `process.stdin` handle the renderer opened, on Windows.
+  //
+  // `createCliRenderer` puts `process.stdin` into raw mode, which opens the
+  // console-input TTY handle. `cleanupBeforeDestroy` removes our data listener,
+  // clears raw mode and calls `pause()` — but none of that *closes* the handle,
+  // and `pause()` does not stop libuv from polling it. On legacy Windows conhost,
+  // if the handle is still open when the event loop turns after `destroy()`, that
+  // poll wedges the console host: `GetConsoleMode` starts returning
+  // ERROR_PIPE_NOT_CONNECTED (233) and the window dies ~0.7s later.
+  //
+  // Measured: `unref()` is NOT enough — it drops the handle from the loop's
+  // keep-alive set but leaves it open and still polled, so the console still
+  // wedges. Only closing the stream (`destroy()`) removes it from the poll set.
+  // A run that closes stdin here survives a full multi-second loop turn after
+  // `destroy()`; the same run with only `unref()` wedges.
+  //
+  // Scoped to Windows (the only place this wedges) and to a handle we own (see
+  // `_ownsStdinHandle`). Never touch a stream a host app is still listening to:
+  // our own `data` listener is already removed by the time this runs, so any
+  // remaining one is theirs. Not called from `suspend()`, which `resume()` follows.
+  private releaseStdinHandle(): void {
+    if (process.platform !== "win32") return
+    if (!this._ownsStdinHandle) return
+    if (this.stdin.listenerCount("data") > 0) return
+    const destroy = (this.stdin as Partial<NodeJS.ReadStream>).destroy
+    if (typeof destroy === "function") {
+      try {
+        destroy.call(this.stdin)
+      } catch (e) {
+        console.error("Error closing stdin handle during destroy:", e)
+      }
     }
   }
 

--- a/packages/core/src/tests/renderer.stdin-handle.test.ts
+++ b/packages/core/src/tests/renderer.stdin-handle.test.ts
@@ -1,0 +1,70 @@
+import { test, expect, afterEach } from "bun:test"
+import { Readable } from "stream"
+import { createCliRenderer } from "../renderer.js"
+import { createTestStdout } from "../testing/test-streams.js"
+
+// A raw-mode-capable stand-in for process.stdin. `createCliRenderer` duck-types
+// `isTTY` and `setRawMode`, so this is enough to drive the real teardown path.
+function makeMockStdin(): NodeJS.ReadStream {
+  const s = new Readable({ read() {} }) as unknown as NodeJS.ReadStream & { isTTY: boolean }
+  s.isTTY = true
+  ;(s as unknown as { setRawMode: (v: boolean) => unknown }).setRawMode = () => s
+  return s
+}
+
+const origStdin = Object.getOwnPropertyDescriptor(process, "stdin")!
+const origPlatform = Object.getOwnPropertyDescriptor(process, "platform")!
+
+function setStdin(s: NodeJS.ReadStream): void {
+  Object.defineProperty(process, "stdin", { value: s, configurable: true })
+}
+function setPlatform(p: NodeJS.Platform): void {
+  Object.defineProperty(process, "platform", { value: p, configurable: true })
+}
+
+afterEach(() => {
+  Object.defineProperty(process, "stdin", origStdin)
+  Object.defineProperty(process, "platform", origPlatform)
+})
+
+// The core fix: on legacy Windows conhost, an open stdin handle polled after
+// destroy() wedges the console host. destroy() must CLOSE the handle we own.
+test("closes the owned process.stdin handle on destroy (win32)", async () => {
+  setPlatform("win32")
+  const mock = makeMockStdin()
+  setStdin(mock)
+  const renderer = await createCliRenderer({ stdout: createTestStdout() })
+  renderer.destroy()
+  expect((mock as unknown as { destroyed: boolean }).destroyed).toBe(true)
+})
+
+// A caller-supplied stdin belongs to the host; never close it.
+test("does not close a caller-supplied config.stdin", async () => {
+  setPlatform("win32")
+  setStdin(makeMockStdin())
+  const supplied = makeMockStdin()
+  const renderer = await createCliRenderer({ stdin: supplied, stdout: createTestStdout() })
+  renderer.destroy()
+  expect((supplied as unknown as { destroyed: boolean }).destroyed).toBe(false)
+})
+
+// The wedge is legacy-conhost-only; do not change stdin lifecycle elsewhere.
+test("does not close stdin on non-win32", async () => {
+  setPlatform("linux")
+  const mock = makeMockStdin()
+  setStdin(mock)
+  const renderer = await createCliRenderer({ stdout: createTestStdout() })
+  renderer.destroy()
+  expect((mock as unknown as { destroyed: boolean }).destroyed).toBe(false)
+})
+
+// If the host was already consuming stdin, it is not ours to close.
+test("does not close stdin a host was already listening to", async () => {
+  setPlatform("win32")
+  const mock = makeMockStdin()
+  mock.on("data", () => {})
+  setStdin(mock)
+  const renderer = await createCliRenderer({ stdout: createTestStdout() })
+  renderer.destroy()
+  expect((mock as unknown as { destroyed: boolean }).destroyed).toBe(false)
+})


### PR DESCRIPTION
# fix(core): close owned stdin handle on destroy to prevent Windows console wedge

Closes #1405.

## Symptom

On the **legacy Windows console host** (`conhost.exe`, not Windows Terminal), a program that
uses `createCliRenderer()` can take the whole console window down shortly after teardown: the
window simply vanishes. It happens when a keypress was delivered during the session **and** the
event loop turns between `renderer.destroy()` and process exit.

## Root cause (corrected from #1405)

`createCliRenderer()` puts `process.stdin` into raw mode, which opens its console-input TTY
handle. `cleanupBeforeDestroy()` already removes our `data` listener, clears raw mode and calls
`stdin.pause()` — but none of that **closes** the handle, and `pause()` does not stop libuv from
polling it. On legacy conhost, if that handle is still open when the loop turns after
`destroy()`, the poll wedges the console host: the parent's `GetConsoleMode` starts returning
`ERROR_PIPE_NOT_CONNECTED` (233) and the window dies ~0.7 s later.

> #1405 (and PR #1436) framed the fix as `unref()`-ing the leaked handle. **Measured, that does
> not work.** `unref()` removes the handle from the loop's keep-alive set (and from
> `process._getActiveHandles()`), but the handle stays **open and is still polled**, so the
> console still wedges. `process._getActiveHandles()` is the wrong instrument here: `unref()`
> flips its boolean to `false` while the bug remains, and `destroy()` fixes the bug while the
> boolean can still read `true` for a tick (the stream is closing but not yet freed). The
> operative act is **closing** the handle — `stream.destroy()` calls `uv_close` synchronously,
> which removes it from the poll set immediately.

## Fix

Close the stdin handle we own at the end of `cleanupBeforeDestroy()`:

- **Scoped to Windows** — the only place this wedges; POSIX stdin teardown is unchanged.
- **Only a handle we own** — `_ownsStdinHandle` is captured in the constructor and is true only
  when `stdin === process.stdin` and nothing was already consuming it. A caller-supplied
  `config.stdin`, or a stdin the host app was already reading, is never touched.
- **Never a handle a host is still listening to** — our own `data` listener is removed before
  this runs, so any remaining `data` listener is the host's; if present, we skip.
- `suspend()` is unaffected (it does its own stdin teardown and is followed by `resume()`).

Cross-runtime safe: `process.platform` and `stream.destroy()` behave the same on Bun and Node.

## Evidence

The console death cannot be reproduced in CI or through a pty — it needs a real `conhost.exe`
window, so it was verified manually with a harness that (a) runs the lifecycle in a real console,
(b) injects a single sentinel keypress, and (c) polls `GetConsoleMode` from the parent to capture
the wedge (err 233) from outside. Environment: Windows 11 **26200.9168**, legacy conhost, Node
**26.7.0** (`--experimental-ffi`), `@opentui/core` built from this branch.

Same harness, same real console, only the teardown differing:

| Teardown | stdin after `destroy()` | loop turns after `destroy()` | Console |
| --- | --- | --- | --- |
| baseline (current `main`) | leaked, open | yes | **wedges** (parent err 233, window dies) |
| `unref()` only (the #1405 / #1436 approach) | off `_getActiveHandles`, still **open** | yes | **wedges** |
| **`destroy()` (this PR)** | **closed** | yes | **survives** (no 233, window lives through a multi-second loop) |
| exit immediately | leaked, open | no | survives |

The two independent survivors — *close the handle* or *never turn the loop* — both point at the
same actor: an open stdin handle polled on a post-`destroy()` loop turn.

## Tests

`packages/core/src/tests/renderer.stdin-handle.test.ts`:

- closes the owned `process.stdin` handle on `destroy()` (win32)
- does **not** close a caller-supplied `config.stdin`
- does **not** close stdin on non-win32
- does **not** close stdin a host was already listening to

`bun test` for the new file passes 4/4. `oxfmt --check`, `oxlint`, and `tsc` are clean on the
changed files. The only failing tests in the affected suites are pre-existing and unrelated
(Ghostty capability / Markdown link cases), confirmed by stashing this change.
