### PR TITLE
fix(native): place Kitty images above cell backgrounds

### DIFF
--- a/packages/native/src/renderer.zig
+++ b/packages/native/src/renderer.zig
@@ -1450,7 +1450,7 @@ pub const CliRenderer = struct {
             placement.placement_id,
             placement.width,
             placement.height,
-            -1_500_000_000 + @as(i32, @intCast(placement.placement_id)),
+            terminal_image.kittyPlacementZ(placement.placement_id),
             self.terminal.isInTmux(),
         );
     }
@@ -2174,7 +2174,7 @@ pub const CliRenderer = struct {
                 if (normalized) 0 else placement.source_y,
                 if (downscaled) placement.pixel_width else placement.source_width,
                 if (downscaled) placement.pixel_height else placement.source_height,
-                -1_500_000_000 + @as(i32, @intCast(placement.placement_id)),
+                terminal_image.kittyPlacementZ(placement.placement_id),
                 tmux,
             );
         }

--- a/packages/native/src/terminal-image.zig
+++ b/packages/native/src/terminal-image.zig
@@ -172,6 +172,15 @@ pub fn writeKittyTransmitFormat(writer: anytype, image: *native_image.Image, id:
     }
 }
 
+// Kitty draws z < INT32_MIN/2 under cells with a non-default background.
+// Image cells almost always sit on themed TUI chrome, so that layer becomes
+// a solid box in terminals that honor the spec (cmux/libghostty). Stay in
+// [INT32_MIN/2, 0): above cell backgrounds, under glyphs. Covering is still
+// done by dropping the placement when reservation cells are overwritten.
+pub fn kittyPlacementZ(placement_id: u32) i32 {
+    return @as(i32, std.math.minInt(i32) / 2) + @as(i32, @intCast(placement_id));
+}
+
 pub fn writeKittyPlacement(
     writer: anytype,
     id: u32,

--- a/packages/native/src/tests/renderer_test.zig
+++ b/packages/native/src/tests/renderer_test.zig
@@ -108,7 +108,7 @@ test "renderer emits Kitty image once and leaves unchanged frame empty" {
     try std.testing.expect(try test_renderer.renderer.getNextBuffer().drawImage(value, image_handle, 0, 0, 1, 1, 0, 0, 0, 0, 1, 1, .auto));
     try std.testing.expectEqual(renderer.RenderStatus.rendered, test_renderer.renderer.render(true));
     try std.testing.expect(std.mem.find(u8, test_renderer.memory.lastWrite(), "\x1b_Ga=t,f=24,s=1,v=1,i=") != null);
-    try std.testing.expect(std.mem.find(u8, test_renderer.memory.lastWrite(), "c=1,r=1,x=0,y=0,w=1,h=1,C=1,z=-1499999999") != null);
+    try std.testing.expect(std.mem.find(u8, test_renderer.memory.lastWrite(), "c=1,r=1,x=0,y=0,w=1,h=1,C=1,z=-1073741823") != null);
 
     try std.testing.expect(try test_renderer.renderer.getNextBuffer().drawImage(value, image_handle, 0, 0, 1, 1, 0, 0, 0, 0, 1, 1, .auto));
     try std.testing.expectEqual(renderer.RenderStatus.rendered, test_renderer.renderer.render(false));

--- a/packages/native/src/tests/terminal-image_test.zig
+++ b/packages/native/src/tests/terminal-image_test.zig
@@ -2,6 +2,15 @@ const std = @import("std");
 const terminal_image = @import("../terminal-image.zig");
 const image = @import("../image.zig");
 
+test "kitty placement z stays above cell backgrounds" {
+    const z = terminal_image.kittyPlacementZ(1);
+    const below_bg = @as(i32, std.math.minInt(i32) / 2);
+    try std.testing.expectEqual(below_bg + 1, z);
+    try std.testing.expect(z < 0);
+    try std.testing.expect(z >= below_bg);
+    try std.testing.expect(terminal_image.kittyPlacementZ(2) > z);
+}
+
 const DecodedSixel = struct {
     indices: []u8,
     width: usize,


### PR DESCRIPTION
## Summary
- Kitty graphics with `z < INT32_MIN/2` are drawn **under non-default cell backgrounds**. OpenTUI used `z = -1_500_000_000 + id`, which is in that band.
- OpenCode 2 thumbnails sit on themed TUI chrome, so those placements become a solid black `[Image 1]` box in terminals that honor the spec (cmux/libghostty). Ghostty.app still showed the overlay; Pi worked because it omits `z` (defaults to 0).
- Place images at `INT32_MIN/2 + placement_id`: above cell backgrounds, under glyphs. Covering is unchanged — a later fill/text still drops the reservation and the placement is not emitted.

Fixes the OpenCode TUI preview path tracked in [opencode#41691](https://github.com/anomalyco/opencode/issues/41691).

## Test plan
- [x] `zig build test -Dtest-filter=Kitty` in `packages/native` (12 passed), including the existing emit-once assertion (now `z=-1073741823`) and covering-plane test
- [ ] Paste an image in OpenCode 2 inside cmux and confirm the thumbnail is sharp, not a black `[Image 1]` box
- [ ] Confirm Ghostty.app still shows the same thumbnail
- [ ] Confirm a later opaque fill over the image still hides it (reservation covering)