### PR TITLE
fix(native): invalidate word layout when replacing active placeholders

### DIFF
--- a/packages/core/src/renderables/__tests__/Textarea.rendering.test.ts
+++ b/packages/core/src/renderables/__tests__/Textarea.rendering.test.ts
@@ -1104,6 +1104,21 @@ describe("Textarea - Rendering Tests", () => {
       expect(editor.plainText).toBe("")
     })
 
+    it("redraws all Unicode placeholder characters after word boundaries change", async () => {
+      const { textarea: editor } = await createTextareaRenderable(currentRenderer, renderOnce, {
+        width: 70,
+        height: 4,
+        wrapMode: "word",
+        placeholder: "Worker running, Esc to stop...",
+      })
+      expect(captureFrame().split("\n")[0].trimEnd()).toBe("Worker running, Esc to stop...")
+
+      editor.placeholder = "Edit \u{1f680} text, / show help..."
+      await renderOnce()
+      expect(captureFrame().split("\n")[0].trimEnd()).toBe("Edit \u{1f680} text, / show help...")
+      expect(editor.plainText).toBe("")
+    })
+
     it("should update placeholder text dynamically", async () => {
       const { textarea: editor } = await createTextareaRenderable(currentRenderer, renderOnce, {
         initialValue: "",

--- a/packages/native/src/editor-view.zig
+++ b/packages/native/src/editor-view.zig
@@ -943,7 +943,9 @@ pub const EditorView = struct {
         try placeholder.setStyledText(chunks);
 
         if (self.placeholder_active) {
-            self.text_buffer_view.virtual_lines_dirty = true;
+            // The view is registered with the edit buffer, so placeholder edits do not
+            // invalidate its word-layout cache. Rebind to discard old byte boundaries.
+            self.text_buffer_view.switchToBuffer(placeholder);
         }
 
         self.updatePlaceholderVisibility();

--- a/packages/native/src/tests/editor-view_test.zig
+++ b/packages/native/src/tests/editor-view_test.zig
@@ -2888,6 +2888,46 @@ test "EditorView - placeholder renders to buffer when empty" {
     try std.testing.expect(!std.mem.startsWith(u8, result2, "Type something..."));
 }
 
+test "EditorView - replacing an active word-wrapped placeholder refreshes byte boundaries" {
+    const pool = gp.initGlobalPool(std.testing.allocator);
+    defer gp.deinitGlobalPool();
+    const link_pool = link.initGlobalLinkPool(std.testing.allocator);
+    defer link.deinitGlobalLinkPool();
+
+    const eb = try EditBuffer.init(std.testing.allocator, pool, link_pool, .wcwidth, null);
+    defer eb.deinit();
+    const ev = try EditorView.init(std.testing.allocator, eb, 70, 4);
+    defer ev.deinit();
+    ev.setWrapMode(.word);
+
+    var screen = try opt_buffer_mod.OptimizedBuffer.init(
+        std.testing.allocator,
+        70,
+        4,
+        .{ .pool = pool, .width_method = .wcwidth },
+    );
+    defer screen.deinit();
+
+    // The viewport fits both strings; only the placeholder's byte/column boundaries change.
+    const placeholders = [_][]const u8{ "Worker running, Esc to stop...", "Edit \u{1f680} text, / show help..." };
+    for (placeholders) |placeholder| {
+        const chunks = [_]text_buffer.StyledChunk{.{
+            .text_ptr = placeholder.ptr,
+            .text_len = placeholder.len,
+            .fg_ptr = null,
+            .bg_ptr = null,
+            .attributes = 0,
+        }};
+        try ev.setPlaceholderStyledText(&chunks);
+        screen.clear(ansi.rgbaFromFloats(0.0, 0.0, 0.0, 1.0), 32);
+        screen.drawEditorView(ev, 0, 0);
+
+        var chars: [1000]u8 = undefined;
+        const written = try screen.writeResolvedChars(&chars, false);
+        try std.testing.expectEqualStrings(placeholder, std.mem.trimEnd(u8, chars[0..written], " \n"));
+    }
+}
+
 test "EditorView - placeholder shrink clears tail and preserves background" {
     const pool = gp.initGlobalPool(std.testing.allocator);
     defer gp.deinitGlobalPool();


### PR DESCRIPTION
Changing an active word-wrapped textarea placeholder can silently drop trailing characters even when the viewport is wide enough. In a 70-column textarea, switch `Worker running, Esc to stop...` to `Edit \u{1f680} text, / show help...` (U+1F680 is a rocket emoji). Before the fix, only one of the three trailing periods is rendered.

`EditorView` registers its text-buffer view with the edit buffer, then temporarily switches the view to the placeholder buffer. Updating that placeholder only marked virtual lines dirty. The placeholder does not own that view registration, so `updateVirtualLines()` could retain the previous placeholder's word-layout metadata and reuse UTF-8 byte boundaries from different text.

Rebind the active placeholder through the existing `switchToBuffer()` path so both virtual lines and the word-layout cache are invalidated. The editor instance and viewport are preserved.

Adds a pure Zig drawing regression and a `TextareaRenderable` character-frame regression. The tests use English text and an escaped Unicode symbol to exercise changing UTF-8 byte and display-cell boundaries. The standalone reproduction fails against both published 0.5.10 and 0.5.11 packages and passes with the native fix; this is not claimed to be exclusive to 0.5.11. No React components or application code are required.

Validation (Windows x64; Bun 1.4.1, Zig 0.16.0, Node 26.7.0, LLVM 22.1.1):
- `bun install --frozen-lockfile`: passed without lockfile changes.
- Root `bun run build`: passed, including native ReleaseFast compilation, Windows DLL/PDB identity validation, symbol separation, and all package builds. No build steps were skipped.
- `bun run test:native` from `packages/core`: 2,115 passed, 62 skipped; native hello example checks passed.
- `bun run test:js` from `packages/core`: 5,674 passed, 36 skipped, 0 failed (239 snapshots).
- `bun run test:js:node` from `packages/core`: 4,927 passed, 17 skipped, 0 failed.
- Core `bun run typecheck`, root `bun run fmt:check`, root `bun run lint:ci`, and `zig fmt --check` on the changed native files: passed.
- The current regression test was also run against the published 0.5.11 native library and failed with the expected missing trailing characters.

Upstream GitHub Actions currently require maintainer approval (`action_required`); the results above are local validation, not a claim that upstream or cross-platform CI has passed.
