### PR TITLE
split footer mangle fix on small terminal sizes

### DIFF
--- a/packages/core/src/renderer.ts
+++ b/packages/core/src/renderer.ts
@@ -3975,7 +3975,6 @@ export class CliRenderer extends EventEmitter implements RenderContext {
       this._footerHeight,
     )
     const prevWidth = this._terminalWidth
-    const previousTerminalHeight = this._terminalHeight
     const visiblePreviousSplitHeight =
       pendingSplitFooterTransition?.sourceHeight ?? previousGeometry.effectiveFooterHeight
 
@@ -3996,12 +3995,12 @@ export class CliRenderer extends EventEmitter implements RenderContext {
     const splitFooterActive = this._screenMode === "split-footer"
 
     if (splitFooterActive) {
-      // Width shrink historically needs a broader scrub band, but if resize interrupts
-      // a deferred footer transition we also need to clear from that visible source surface.
+      // Width changes need the historical broader scrub band without starting
+      // below the visible footer surface. Interrupted transitions may have an earlier source.
       let clearStart: number | null = null
 
-      if (width < prevWidth && visiblePreviousSplitHeight > 0) {
-        clearStart = Math.max(previousTerminalHeight - visiblePreviousSplitHeight * 2, 1)
+      if (width !== prevWidth && visiblePreviousSplitHeight > 0) {
+        clearStart = Math.min(this.renderOffset + 1, Math.max(height - visiblePreviousSplitHeight * 2, 1))
       }
 
       if (pendingSplitFooterTransition !== null) {

--- a/packages/core/src/tests/renderer.console-startup.test.ts
+++ b/packages/core/src/tests/renderer.console-startup.test.ts
@@ -1774,6 +1774,78 @@ test("CliRenderer split-footer resize cleanup uses the visible footer surface wh
   writeOutSpy.mockRestore()
 })
 
+test("CliRenderer split-footer width shrink clears from the visible settling footer origin", async () => {
+  const result = await createTestRenderer({
+    width: 80,
+    height: 24,
+    screenMode: "split-footer",
+    footerHeight: 6,
+    externalOutputMode: "capture-stdout",
+    consoleMode: "disabled",
+  })
+
+  renderer = result.renderer
+  ;(renderer as any)._terminalIsSetup = true
+
+  expect((renderer as any).renderOffset).toBe(1)
+
+  const writeOutSpy = spyOn(renderer as any, "writeOut")
+
+  result.resize(44, 22)
+
+  expect(writeOutSpy).toHaveBeenCalledTimes(1)
+  expect(writeOutSpy.mock.calls[0]?.[0]).toBe(ANSI.moveCursorAndClear(2, 1))
+
+  writeOutSpy.mockRestore()
+})
+
+test("CliRenderer split-footer width shrink retains the broader scrub band when pinned", async () => {
+  const result = await createTestRenderer({
+    width: 80,
+    height: 24,
+    screenMode: "split-footer",
+    footerHeight: 6,
+    externalOutputMode: "capture-stdout",
+    consoleMode: "disabled",
+  })
+
+  renderer = result.renderer
+  ;(renderer as any)._terminalIsSetup = true
+  ;(renderer as any).renderOffset = 18
+
+  const writeOutSpy = spyOn(renderer as any, "writeOut")
+
+  result.resize(44, 24)
+
+  expect(writeOutSpy).toHaveBeenCalledTimes(1)
+  expect(writeOutSpy.mock.calls[0]?.[0]).toBe(ANSI.moveCursorAndClear(12, 1))
+
+  writeOutSpy.mockRestore()
+})
+
+test("CliRenderer split-footer combined shrink accounts for the new terminal height", async () => {
+  const result = await createTestRenderer({
+    width: 80,
+    height: 24,
+    screenMode: "split-footer",
+    footerHeight: 6,
+    externalOutputMode: "capture-stdout",
+    consoleMode: "disabled",
+  })
+
+  renderer = result.renderer
+  ;(renderer as any)._terminalIsSetup = true
+
+  const writeOutSpy = spyOn(renderer as any, "writeOut")
+
+  result.resize(44, 10)
+
+  expect(writeOutSpy).toHaveBeenCalledTimes(1)
+  expect(writeOutSpy.mock.calls[0]?.[0]).toBe(ANSI.moveCursorAndClear(1, 1))
+
+  writeOutSpy.mockRestore()
+})
+
 test("CliRenderer split-footer resize cleanup uses the visible source top line across width and height resize while a deferred footer transition is pending", async () => {
   const result = await createTestRenderer({
     width: 40,


### PR DESCRIPTION
Hi @simonklee / @kommander 

fixes: #1486 

This is a small patch work to fix the mangling of split footer below a certain terminal size & offset. the issue was that on resize, the code never cleared anything between a certain rows in the older calculation. now it always clears from row 2 to make sure the footer is redrawn at the correct shape and size.

Let me know if I missed anything or correction is needed anywhere.

Thanks

https://github.com/user-attachments/assets/5842eab7-32e2-45b7-a32a-891bc2acf388
