### PR TITLE
chore(ci): switched to recommended relative workflow syntax

### DIFF
--- a/.github/workflows/build-core.yml
+++ b/.github/workflows/build-core.yml
@@ -48,7 +48,7 @@ jobs:
         run: bun install
 
       - name: Setup cross-platform symbol tools
-        uses: ./.github/actions/setup-native-symbol-tools
+        uses: $/.github/actions/setup-native-symbol-tools
 
       - name: Build native libraries (cross-compile all platforms)
         run: |
@@ -140,7 +140,7 @@ jobs:
 
       - name: Enable Linux core dumps
         if: runner.os == 'Linux'
-        uses: ./.github/actions/enable-linux-coredumps
+        uses: $/.github/actions/enable-linux-coredumps
 
       - name: Run native tests
         working-directory: packages/core
@@ -186,7 +186,7 @@ jobs:
 
       - name: Upload Linux core dumps
         if: failure() && runner.os == 'Linux'
-        uses: ./.github/actions/upload-linux-coredumps
+        uses: $/.github/actions/upload-linux-coredumps
         with:
           name: crash-dumps-core-${{ matrix.os }}-${{ github.run_attempt }}
 

--- a/.github/workflows/build-keymap.yml
+++ b/.github/workflows/build-keymap.yml
@@ -67,7 +67,7 @@ jobs:
 
       - name: Enable Linux core dumps
         if: runner.os == 'Linux'
-        uses: ./.github/actions/enable-linux-coredumps
+        uses: $/.github/actions/enable-linux-coredumps
 
       - name: Run tests
         run: |
@@ -77,7 +77,7 @@ jobs:
 
       - name: Upload Linux core dumps
         if: failure() && runner.os == 'Linux'
-        uses: ./.github/actions/upload-linux-coredumps
+        uses: $/.github/actions/upload-linux-coredumps
         with:
           name: crash-dumps-keymap-${{ matrix.os }}-${{ github.run_attempt }}
 

--- a/.github/workflows/build-native.yml
+++ b/.github/workflows/build-native.yml
@@ -55,7 +55,7 @@ jobs:
         run: bun install
 
       - name: Setup cross-platform symbol tools
-        uses: ./.github/actions/setup-native-symbol-tools
+        uses: $/.github/actions/setup-native-symbol-tools
 
       - name: Build packages (cross-compile for all platforms)
         run: |

--- a/.github/workflows/build-qrcode.yml
+++ b/.github/workflows/build-qrcode.yml
@@ -65,7 +65,7 @@ jobs:
 
       - name: Enable Linux core dumps
         if: runner.os == 'Linux'
-        uses: ./.github/actions/enable-linux-coredumps
+        uses: $/.github/actions/enable-linux-coredumps
 
       - name: Run tests
         run: |
@@ -75,7 +75,7 @@ jobs:
 
       - name: Upload Linux core dumps
         if: failure() && runner.os == 'Linux'
-        uses: ./.github/actions/upload-linux-coredumps
+        uses: $/.github/actions/upload-linux-coredumps
         with:
           name: crash-dumps-qrcode-${{ matrix.os }}-${{ github.run_attempt }}
 

--- a/.github/workflows/build-react.yml
+++ b/.github/workflows/build-react.yml
@@ -66,7 +66,7 @@ jobs:
 
       - name: Enable Linux core dumps
         if: runner.os == 'Linux'
-        uses: ./.github/actions/enable-linux-coredumps
+        uses: $/.github/actions/enable-linux-coredumps
 
       - name: Run tests
         run: |
@@ -76,7 +76,7 @@ jobs:
 
       - name: Upload Linux core dumps
         if: failure() && runner.os == 'Linux'
-        uses: ./.github/actions/upload-linux-coredumps
+        uses: $/.github/actions/upload-linux-coredumps
         with:
           name: crash-dumps-react-${{ matrix.os }}-${{ github.run_attempt }}
 

--- a/.github/workflows/build-solid.yml
+++ b/.github/workflows/build-solid.yml
@@ -66,7 +66,7 @@ jobs:
 
       - name: Enable Linux core dumps
         if: runner.os == 'Linux'
-        uses: ./.github/actions/enable-linux-coredumps
+        uses: $/.github/actions/enable-linux-coredumps
 
       - name: Run tests
         working-directory: packages/solid
@@ -76,7 +76,7 @@ jobs:
 
       - name: Upload Linux core dumps
         if: failure() && runner.os == 'Linux'
-        uses: ./.github/actions/upload-linux-coredumps
+        uses: $/.github/actions/upload-linux-coredumps
         with:
           name: crash-dumps-solid-${{ matrix.os }}-${{ github.run_attempt }}
 

--- a/.github/workflows/build-ssh.yml
+++ b/.github/workflows/build-ssh.yml
@@ -74,7 +74,7 @@ jobs:
 
       - name: Enable Linux core dumps
         if: runner.os == 'Linux'
-        uses: ./.github/actions/enable-linux-coredumps
+        uses: $/.github/actions/enable-linux-coredumps
 
       - name: Run tests
         run: |
@@ -84,7 +84,7 @@ jobs:
 
       - name: Upload Linux core dumps
         if: failure() && runner.os == 'Linux'
-        uses: ./.github/actions/upload-linux-coredumps
+        uses: $/.github/actions/upload-linux-coredumps
         with:
           name: crash-dumps-ssh-${{ matrix.os }}-${{ github.run_attempt }}
 

--- a/.github/workflows/pkg-pr-new.yml
+++ b/.github/workflows/pkg-pr-new.yml
@@ -47,7 +47,7 @@ jobs:
         run: bun install
 
       - name: Setup native symbol tools
-        uses: ./.github/actions/setup-native-symbol-tools
+        uses: $/.github/actions/setup-native-symbol-tools
 
       - name: Build core (all platforms via cross-compilation)
         run: bun run build:native --all && bun scripts/build.ts --lib

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -109,7 +109,7 @@ jobs:
     name: Build Native
     if: ${{ !contains(github.ref_name, 'snapshot') }}
     needs: [prepare, validate-version]
-    uses: ./.github/workflows/build-native.yml
+    uses: $/.github/workflows/build-native.yml
     with:
       version: ${{ needs.prepare.outputs.fullTag }}
 
@@ -118,7 +118,7 @@ jobs:
     name: Build Examples
     if: ${{ !contains(github.ref_name, 'snapshot') }}
     needs: [prepare, sign-windows-artifacts]
-    uses: ./.github/workflows/build-examples.yml
+    uses: $/.github/workflows/build-examples.yml
     with:
       version: ${{ needs.prepare.outputs.fullTag }}
 
@@ -127,7 +127,7 @@ jobs:
     name: NPM Publish
     if: ${{ !contains(github.ref_name, 'snapshot') }}
     needs: [prepare, sign-windows-artifacts]
-    uses: ./.github/workflows/npm-latest-release.yml
+    uses: $/.github/workflows/npm-latest-release.yml
     permissions:
       contents: read
       id-token: write
@@ -315,7 +315,7 @@ jobs:
     name: Build NPM Snapshot
     if: ${{ contains(github.ref_name, 'snapshot') }}
     needs: snapshot-prepare
-    uses: ./.github/workflows/build-native.yml
+    uses: $/.github/workflows/build-native.yml
     with:
       version: ${{ needs.snapshot-prepare.outputs.version }}
       prepareVersion: ${{ needs.snapshot-prepare.outputs.version }}
@@ -326,7 +326,7 @@ jobs:
     name: Publish NPM Snapshot
     if: ${{ contains(github.ref_name, 'snapshot') }}
     needs: [snapshot-prepare, snapshot-build]
-    uses: ./.github/workflows/npm-latest-release.yml
+    uses: $/.github/workflows/npm-latest-release.yml
     permissions:
       contents: read
       id-token: write


### PR DESCRIPTION
This should provide a modest performance increase [according to the docs](https://github.blog/changelog/2026-07-30-reference-same-repository-actions-with-self-repository-syntax/).

FYI I just ran `sed` on these:

```shell
sed --in-place 's|uses: \.|uses: $|g' .github/workflows/*.*
```